### PR TITLE
feat(hatchet): add cast() method to EventDefinition

### DIFF
--- a/packages/hatchet/src/events/event-definition.spec.ts
+++ b/packages/hatchet/src/events/event-definition.spec.ts
@@ -112,3 +112,58 @@ describe("#isCtx()", () => {
 		expect(() => event.isCtx(ctx)).toThrow(/payload is malformed/);
 	});
 });
+
+describe("#cast()", () => {
+	const event = defineEvent("user:created", testSchema);
+
+	it("returns true for a valid object without the event marker", () => {
+		const ctx = { input: { userId: "123", email: "test@example.com" } };
+
+		expect(event.cast(ctx)).toBe(true);
+	});
+
+	it("returns false when context input is not an object", () => {
+		const ctx = { input: "not an object" };
+
+		expect(event.cast(ctx)).toBe(false);
+	});
+
+	it("returns false when context input is null", () => {
+		const ctx = { input: null };
+
+		expect(event.cast(ctx)).toBe(false);
+	});
+
+	it("throws when payload fails schema validation", () => {
+		const ctx = { input: { userId: "123", email: "not-an-email" } };
+
+		expect(() => event.cast(ctx)).toThrow(/payload is malformed/);
+	});
+
+	it("throws when required field is missing", () => {
+		const ctx = { input: { userId: "123" } };
+
+		expect(() => event.cast(ctx)).toThrow(/payload is malformed/);
+	});
+
+	it("returns true for payload that has the marker (marker is irrelevant to cast)", () => {
+		const ctx = {
+			input: {
+				userId: "123",
+				email: "test@example.com",
+				[EVENT_MARKER]: "other:event",
+			},
+		};
+
+		expect(event.cast(ctx)).toBe(true);
+	});
+
+	describe("contrast with isCtx()", () => {
+		it("returns true for marker-free valid input where isCtx returns false", () => {
+			const ctx = { input: { userId: "123", email: "test@example.com" } };
+
+			expect(event.cast(ctx)).toBe(true);
+			expect(event.isCtx(ctx)).toBe(false);
+		});
+	});
+});

--- a/packages/hatchet/src/events/event-definition.ts
+++ b/packages/hatchet/src/events/event-definition.ts
@@ -44,6 +44,46 @@ export class EventDefinition<
 	}
 
 	/**
+	 * Type guard: casts the context input to this event's schema output type
+	 * without requiring the event marker to be present.
+	 *
+	 * Use this for externally sourced events that arrive without the marker
+	 * injected by Client.emit(). Schema validation still runs and throws if
+	 * the payload is malformed.
+	 *
+	 * @param ctx The context to check (TaskCtx, WorkflowCtx, HelperCtx, or SDK Context).
+	 * @returns True if the context input is a non-null object that passes schema validation.
+	 * @throws Error if the payload fails schema validation.
+	 */
+	public cast<C extends { input: unknown }>(
+		ctx: C,
+	): ctx is C & { input: StandardSchemaV1.InferOutput<TSchema> } {
+		// Require a non-null object as a baseline guard
+		if (typeof ctx.input !== "object" || ctx.input === null) {
+			return false;
+		}
+
+		// Validate the input against the schema
+		const result = this.schema["~standard"].validate(ctx.input);
+
+		// Handle async validation - not supported
+		if (result instanceof Promise) {
+			throw new Error(
+				`Event '${this.name}' schema validation must be synchronous. Use a sync schema.`,
+			);
+		}
+
+		// Check for validation errors
+		if ("issues" in result && result.issues) {
+			throw new Error(
+				`Event '${this.name}' payload is malformed: ${JSON.stringify(result.issues)}`,
+			);
+		}
+
+		return true;
+	}
+
+	/**
 	 * Type guard: checks if the context was triggered by this event.
 	 * Validates the input against the event schema and throws if malformed.
 	 *
@@ -66,24 +106,8 @@ export class EventDefinition<
 			return false;
 		}
 
-		// Validate the input against the schema
-		const result = this.schema["~standard"].validate(ctx.input);
-
-		// Handle async validation - not supported
-		if (result instanceof Promise) {
-			throw new Error(
-				`Event '${this.name}' schema validation must be synchronous. Use a sync schema.`,
-			);
-		}
-
-		// Check for validation errors
-		if ("issues" in result && result.issues) {
-			throw new Error(
-				`Event '${this.name}' payload is malformed: ${JSON.stringify(result.issues)}`,
-			);
-		}
-
-		return true;
+		// Delegate schema validation to cast
+		return this.cast(ctx);
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `cast()` to `EventDefinition` — a marker-free type guard that validates the context input against the schema without requiring the `__event_name` marker. Designed for externally sourced events that cannot have the marker injected.
- Refactors `isCtx()` to delegate its schema validation leg to `cast()`, removing duplicated validation code.
- Adds 7 tests for `cast()` including a contrast test showing it passes where `isCtx()` would return false on the same marker-free input.

## Test plan

- [ ] All existing `#isCtx()` tests pass unchanged
- [ ] All new `#cast()` tests pass (valid payload, null/non-object, malformed payload throws, marker-irrelevant pass, contrast with isCtx)