### PR TITLE
feat(exceptions): add entity sub-path export with Entity* prefixes

### DIFF
--- a/packages/exceptions/package.json
+++ b/packages/exceptions/package.json
@@ -25,6 +25,11 @@
 			"types": "./dist/index.d.ts",
 			"require": "./dist/index.js",
 			"default": "./dist/index.js"
+		},
+		"./entity": {
+			"types": "./dist/entity.d.ts",
+			"require": "./dist/entity.js",
+			"default": "./dist/entity.js"
 		}
 	},
 	"files": [

--- a/packages/exceptions/src/entity-focused/mutation-failed.exception.spec.ts
+++ b/packages/exceptions/src/entity-focused/mutation-failed.exception.spec.ts
@@ -4,7 +4,7 @@ import {
 	configureEntityNameRenderer,
 	resetEntityNameRenderer,
 } from "./entity-name-renderer";
-import { MutationFailedException } from "./mutation-failed.exception";
+import { EntityMutationFailedException } from "./mutation-failed.exception";
 
 describe("entity-focused/mutation-failed.exception.ts", () => {
 	afterEach(() => {
@@ -13,7 +13,7 @@ describe("entity-focused/mutation-failed.exception.ts", () => {
 
 	describe("mutationFailedException", () => {
 		it("creates error for create mutation", () => {
-			const error = new MutationFailedException({
+			const error = new EntityMutationFailedException({
 				entity: "user",
 				entityId: "123",
 				mutationType: "create",
@@ -23,7 +23,7 @@ describe("entity-focused/mutation-failed.exception.ts", () => {
 		});
 
 		it("creates error for update mutation", () => {
-			const error = new MutationFailedException({
+			const error = new EntityMutationFailedException({
 				entity: "user",
 				entityId: "123",
 				mutationType: "update",
@@ -33,7 +33,7 @@ describe("entity-focused/mutation-failed.exception.ts", () => {
 		});
 
 		it("creates error for delete mutation", () => {
-			const error = new MutationFailedException({
+			const error = new EntityMutationFailedException({
 				entity: "user",
 				entityId: "123",
 				mutationType: "delete",
@@ -45,7 +45,7 @@ describe("entity-focused/mutation-failed.exception.ts", () => {
 		it("creates error with configured renderer", () => {
 			configureEntityNameRenderer({ user: "User" });
 
-			const error = new MutationFailedException({
+			const error = new EntityMutationFailedException({
 				entity: "user",
 				entityId: "123",
 				mutationType: "update",
@@ -55,7 +55,7 @@ describe("entity-focused/mutation-failed.exception.ts", () => {
 		});
 
 		it("has correct code", () => {
-			const error = new MutationFailedException({
+			const error = new EntityMutationFailedException({
 				entity: "user",
 				entityId: "123",
 				mutationType: "create",
@@ -65,7 +65,7 @@ describe("entity-focused/mutation-failed.exception.ts", () => {
 		});
 
 		it("has correct httpStatus", () => {
-			const error = new MutationFailedException({
+			const error = new EntityMutationFailedException({
 				entity: "user",
 				entityId: "123",
 				mutationType: "create",
@@ -75,7 +75,7 @@ describe("entity-focused/mutation-failed.exception.ts", () => {
 		});
 
 		it("stores mutationType", () => {
-			const error = new MutationFailedException({
+			const error = new EntityMutationFailedException({
 				entity: "user",
 				entityId: "123",
 				mutationType: "delete",
@@ -85,7 +85,7 @@ describe("entity-focused/mutation-failed.exception.ts", () => {
 		});
 
 		it("stores entity and entityId", () => {
-			const error = new MutationFailedException({
+			const error = new EntityMutationFailedException({
 				entity: "user",
 				entityId: "123",
 				mutationType: "create",
@@ -96,7 +96,7 @@ describe("entity-focused/mutation-failed.exception.ts", () => {
 		});
 
 		it("sets meta with entity info", () => {
-			const error = new MutationFailedException({
+			const error = new EntityMutationFailedException({
 				entity: "user",
 				entityId: "123",
 				mutationType: "create",

--- a/packages/exceptions/src/entity-focused/mutation-failed.exception.ts
+++ b/packages/exceptions/src/entity-focused/mutation-failed.exception.ts
@@ -9,16 +9,16 @@ import type { EntityFocusedArgs } from "./entity-focused.interface";
 /**
  * The type of mutation that failed.
  */
-export type MutationType = "create" | "update" | "delete";
+export type EntityMutationType = "create" | "update" | "delete";
 
 /**
- * Arguments for creating a MutationFailedException.
+ * Arguments for creating an EntityMutationFailedException.
  */
-export interface MutationFailedArgs extends EntityFocusedArgs {
+export interface EntityMutationFailedArgs extends EntityFocusedArgs {
 	/**
 	 * The type of mutation that failed.
 	 */
-	mutationType: MutationType;
+	mutationType: EntityMutationType;
 }
 
 /**
@@ -27,7 +27,7 @@ export interface MutationFailedArgs extends EntityFocusedArgs {
  * @example
  * ```typescript
  * // Basic usage
- * throw new MutationFailedException({
+ * throw new EntityMutationFailedException({
  *   entity: 'user',
  *   entityId: '123',
  *   mutationType: 'update',
@@ -36,7 +36,7 @@ export interface MutationFailedArgs extends EntityFocusedArgs {
  *
  * // With configured entity name renderer
  * configureEntityNameRenderer({ user: 'User' });
- * throw new MutationFailedException({
+ * throw new EntityMutationFailedException({
  *   entity: 'user',
  *   entityId: '123',
  *   mutationType: 'delete',
@@ -44,7 +44,7 @@ export interface MutationFailedArgs extends EntityFocusedArgs {
  * // Error message: "Failed to delete User with ID '123'"
  * ```
  */
-export class MutationFailedException
+export class EntityMutationFailedException
 	extends EntityFocusedAppException
 	implements HttpAwareException
 {
@@ -54,16 +54,16 @@ export class MutationFailedException
 	/**
 	 * The type of mutation that failed.
 	 */
-	public readonly mutationType: MutationType;
+	public readonly mutationType: EntityMutationType;
 
 	/**
-	 * Creates a new MutationFailedException.
+	 * Creates a new EntityMutationFailedException.
 	 *
 	 * @param args - The entity type, ID, and mutation type
 	 * @param opts - Additional exception options
 	 */
 	public constructor(
-		args: MutationFailedArgs,
+		args: EntityMutationFailedArgs,
 		opts?: AppExceptionOptsWithoutMeta,
 	) {
 		super(

--- a/packages/exceptions/src/entity-focused/not-found.exception.spec.ts
+++ b/packages/exceptions/src/entity-focused/not-found.exception.spec.ts
@@ -4,7 +4,7 @@ import {
 	configureEntityNameRenderer,
 	resetEntityNameRenderer,
 } from "./entity-name-renderer";
-import { NotFoundException } from "./not-found.exception";
+import { EntityNotFoundException } from "./not-found.exception";
 
 describe("entity-focused/not-found.exception.ts", () => {
 	afterEach(() => {
@@ -13,7 +13,7 @@ describe("entity-focused/not-found.exception.ts", () => {
 
 	describe("notFoundException", () => {
 		it("creates error with default renderer", () => {
-			const error = new NotFoundException({
+			const error = new EntityNotFoundException({
 				entity: "user",
 				entityId: "123",
 			});
@@ -24,7 +24,7 @@ describe("entity-focused/not-found.exception.ts", () => {
 		it("creates error with configured renderer", () => {
 			configureEntityNameRenderer({ user: "User Account" });
 
-			const error = new NotFoundException({
+			const error = new EntityNotFoundException({
 				entity: "user",
 				entityId: "123",
 			});
@@ -33,7 +33,7 @@ describe("entity-focused/not-found.exception.ts", () => {
 		});
 
 		it("has correct code", () => {
-			const error = new NotFoundException({
+			const error = new EntityNotFoundException({
 				entity: "user",
 				entityId: "123",
 			});
@@ -42,7 +42,7 @@ describe("entity-focused/not-found.exception.ts", () => {
 		});
 
 		it("has correct httpStatus", () => {
-			const error = new NotFoundException({
+			const error = new EntityNotFoundException({
 				entity: "user",
 				entityId: "123",
 			});
@@ -51,7 +51,7 @@ describe("entity-focused/not-found.exception.ts", () => {
 		});
 
 		it("stores entity and entityId", () => {
-			const error = new NotFoundException({
+			const error = new EntityNotFoundException({
 				entity: "user",
 				entityId: "123",
 			});
@@ -63,7 +63,7 @@ describe("entity-focused/not-found.exception.ts", () => {
 		it("stores entityDisplayName", () => {
 			configureEntityNameRenderer({ user: "User" });
 
-			const error = new NotFoundException({
+			const error = new EntityNotFoundException({
 				entity: "user",
 				entityId: "123",
 			});
@@ -72,7 +72,7 @@ describe("entity-focused/not-found.exception.ts", () => {
 		});
 
 		it("sets meta with entity info", () => {
-			const error = new NotFoundException({
+			const error = new EntityNotFoundException({
 				entity: "user",
 				entityId: "123",
 			});
@@ -85,7 +85,7 @@ describe("entity-focused/not-found.exception.ts", () => {
 
 		it("accepts additional options", () => {
 			const cause = new Error("DB error");
-			const error = new NotFoundException(
+			const error = new EntityNotFoundException(
 				{ entity: "user", entityId: "123" },
 				{ cause, sourcePointer: "/data/user" },
 			);

--- a/packages/exceptions/src/entity-focused/not-found.exception.ts
+++ b/packages/exceptions/src/entity-focused/not-found.exception.ts
@@ -12,16 +12,16 @@ import type { EntityFocusedArgs } from "./entity-focused.interface";
  * @example
  * ```typescript
  * // Basic usage
- * throw new NotFoundException({ entity: 'user', entityId: '123' });
+ * throw new EntityNotFoundException({ entity: 'user', entityId: '123' });
  * // Error message: "user with ID '123' not found"
  *
  * // With configured entity name renderer
  * configureEntityNameRenderer({ user: 'User' });
- * throw new NotFoundException({ entity: 'user', entityId: '123' });
+ * throw new EntityNotFoundException({ entity: 'user', entityId: '123' });
  * // Error message: "User with ID '123' not found"
  * ```
  */
-export class NotFoundException
+export class EntityNotFoundException
 	extends EntityFocusedAppException
 	implements HttpAwareException
 {
@@ -29,7 +29,7 @@ export class NotFoundException
 	public readonly httpStatus = 404;
 
 	/**
-	 * Creates a new NotFoundException.
+	 * Creates a new EntityNotFoundException.
 	 *
 	 * @param args - The entity type and ID that was not found
 	 * @param opts - Additional exception options

--- a/packages/exceptions/src/entity.ts
+++ b/packages/exceptions/src/entity.ts
@@ -1,0 +1,7 @@
+/**
+ * @abinnovision/nestjs-exceptions/entity
+ *
+ * Entity-focused exceptions for NestJS applications.
+ */
+
+export * from "./entity-focused";

--- a/packages/exceptions/src/index.ts
+++ b/packages/exceptions/src/index.ts
@@ -7,4 +7,3 @@
 export * from "./app-exception";
 export * from "./multi-app-exception";
 export * from "./generic-exception-filter";
-export * from "./entity-focused";


### PR DESCRIPTION
Moves all entity-focused exceptions behind a dedicated `@abinnovision/nestjs-exceptions/entity` sub-path export so consumers importing only from the root are no longer polluted with entity-specific symbols. Renames `NotFoundException` → `EntityNotFoundException`, `MutationFailedException` → `EntityMutationFailedException`, and their supporting types (`MutationType` → `EntityMutationType`, `MutationFailedArgs` → `EntityMutationFailedArgs`). The new entry point `src/entity.ts` re-exports the full `entity-focused` module, and `package.json` exposes it via the `./entity` exports condition. The root `index.ts` no longer re-exports entity-focused symbols.