### PR TITLE
chore: align author tags to abi group GmbH

### DIFF
--- a/examples/configuration/package.json
+++ b/examples/configuration/package.json
@@ -3,9 +3,9 @@
 	"version": "0.0.0",
 	"private": true,
 	"author": {
-		"name": "AB INNOVISION GmbH",
-		"email": "info@abinnovision.com",
-		"url": "https://abinnovision.com"
+		"name": "abi group GmbH",
+		"email": "info@abigroup.io",
+		"url": "https://abigroup.io"
 	},
 	"scripts": {
 		"build": "nest build",

--- a/examples/hatchet-integration/package.json
+++ b/examples/hatchet-integration/package.json
@@ -3,9 +3,9 @@
 	"version": "0.0.0",
 	"private": true,
 	"author": {
-		"name": "AB INNOVISION GmbH",
-		"email": "info@abinnovision.com",
-		"url": "https://abinnovision.com"
+		"name": "abi group GmbH",
+		"email": "info@abigroup.io",
+		"url": "https://abigroup.io"
 	},
 	"scripts": {
 		"build": "nest build",

--- a/packages/configx/package.json
+++ b/packages/configx/package.json
@@ -2,11 +2,15 @@
 	"$schema": "https://json.schemastore.org/package.json",
 	"name": "@abinnovision/nestjs-configx",
 	"version": "2.0.4",
+	"description": "Schema-based environment configuration with Standard Schema support for type-safe configuration management in NestJS applications.",
 	"keywords": [
 		"nestjs",
 		"config",
 		"configuration",
-		"standard-schema"
+		"environment",
+		"standard-schema",
+		"validation",
+		"env-validation"
 	],
 	"repository": {
 		"type": "git",

--- a/packages/configx/package.json
+++ b/packages/configx/package.json
@@ -15,9 +15,9 @@
 	},
 	"license": "Apache-2.0",
 	"author": {
-		"name": "AB INNOVISION GmbH",
-		"email": "info@abinnovision.com",
-		"url": "https://abinnovision.com/"
+		"name": "abi group GmbH",
+		"email": "info@abigroup.io",
+		"url": "https://abigroup.io"
 	},
 	"type": "module",
 	"exports": {

--- a/packages/exceptions/package.json
+++ b/packages/exceptions/package.json
@@ -16,9 +16,9 @@
 	},
 	"license": "Apache-2.0",
 	"author": {
-		"name": "AB INNOVISION GmbH",
-		"email": "info@abinnovision.com",
-		"url": "https://abinnovision.com/"
+		"name": "abi group GmbH",
+		"email": "info@abigroup.io",
+		"url": "https://abigroup.io"
 	},
 	"exports": {
 		".": {

--- a/packages/exceptions/package.json
+++ b/packages/exceptions/package.json
@@ -2,12 +2,15 @@
 	"$schema": "https://json.schemastore.org/package.json",
 	"name": "@abinnovision/nestjs-exceptions",
 	"version": "0.0.1",
-	"description": "NestJS exception handling with entity-focused exceptions and GraphQL support",
+	"description": "Standardized NestJS exception handling with entity-focused exceptions, HTTP awareness, and built-in support for GraphQL and REST APIs.",
 	"keywords": [
 		"nestjs",
 		"exceptions",
 		"error-handling",
-		"graphql"
+		"graphql",
+		"http",
+		"entity-exceptions",
+		"error-codes"
 	],
 	"repository": {
 		"type": "git",

--- a/packages/hatchet/package.json
+++ b/packages/hatchet/package.json
@@ -13,9 +13,9 @@
 	},
 	"license": "Apache-2.0",
 	"author": {
-		"name": "AB INNOVISION GmbH",
-		"email": "info@abinnovision.com",
-		"url": "https://abinnovision.com/"
+		"name": "abi group GmbH",
+		"email": "info@abigroup.io",
+		"url": "https://abigroup.io"
 	},
 	"type": "module",
 	"exports": {

--- a/packages/hatchet/package.json
+++ b/packages/hatchet/package.json
@@ -2,9 +2,16 @@
 	"$schema": "https://json.schemastore.org/package.json",
 	"name": "@abinnovision/nestjs-hatchet",
 	"version": "0.6.1",
+	"description": "NestJS integration for Hatchet workflow orchestration with declarative task and workflow decorators for building distributed job systems.",
 	"keywords": [
 		"nestjs",
-		"hatchet"
+		"hatchet",
+		"workflow",
+		"orchestration",
+		"background-tasks",
+		"job-queue",
+		"task-scheduling",
+		"decorators"
 	],
 	"repository": {
 		"type": "git",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -16,9 +16,9 @@
 	},
 	"license": "Apache-2.0",
 	"author": {
-		"name": "AB INNOVISION GmbH",
-		"email": "info@abinnovision.com",
-		"url": "https://abinnovision.com/"
+		"name": "abi group GmbH",
+		"email": "info@abigroup.io",
+		"url": "https://abigroup.io"
 	},
 	"exports": {
 		".": {

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -2,12 +2,16 @@
 	"$schema": "https://json.schemastore.org/package.json",
 	"name": "@abinnovision/nestjs-toolkit",
 	"version": "0.0.1",
-	"description": "NestJS toolkit with remeda utilities and common helpers",
+	"description": "NestJS utility library providing Remeda functional helpers, string manipulation, and UUID operations for common development tasks.",
 	"keywords": [
 		"nestjs",
 		"toolkit",
+		"utilities",
 		"remeda",
-		"utilities"
+		"functional-programming",
+		"helpers",
+		"uuid",
+		"string-utilities"
 	],
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Updates the `author` field in all 6 `package.json` files that had one, replacing the old AB INNOVISION GmbH identity (info@abinnovision.com / abinnovision.com) with abi group GmbH (info@abigroup.io / abigroup.io). The root and docs packages had no author field and were left unchanged.