### PR TITLE
feat(toolkit): split data-first helpers from remeda-compatible R namespace

### DIFF
--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -1,91 +1,33 @@
 # @abinnovision/nestjs-toolkit
 
-NestJS toolkit with remeda utilities and common helpers.
+Common helpers for NestJS apps, with [remeda](https://remedajs.com/) re-exported as `R`.
 
 ## Installation
 
 ```bash
-npm install @abinnovision/nestjs-toolkit
-# or
 yarn add @abinnovision/nestjs-toolkit
 ```
 
-## Features
-
-- **Remeda as R**: Re-exports [remeda](https://remedajs.com/) as `R` for convenient functional utilities
-- **String utilities**: Pipe-compatible `slugify` and `sanitizeString` functions
-- **UUID utilities**: Simple `isUuid` and `generateUuid` helpers
-
 ## Usage
 
+The package exposes two surfaces:
+
+- **Direct, data-first helpers** — `slugify(data, opts?)`, `sanitizeString(data, opts?)`, `generateUUID(...)`, `isUUID(...)`, `isNullishOrEmptyString(...)`, plus UUID namespace constants and types.
+- **`R` namespace** — every function from `remeda` plus data-last / pipe-friendly variants of the helpers above: `R.slugify(opts?)`, `R.sanitizeString(opts?)`, `R.isUUID`, `R.isNullishOrEmptyString`.
+
 ```typescript
-import {
-  R,
-  slugify,
-  sanitizeString,
-  isUuid,
-  generateUuid,
-} from "@abinnovision/nestjs-toolkit";
+import { R, slugify, generateUUID, isUUID } from "@abinnovision/nestjs-toolkit";
 
-// Use remeda utilities via R
-const doubled = R.pipe(
-  [1, 2, 3],
-  R.map((x) => x * 2),
-);
+slugify("Hello World!"); // "hello-world"
 
-// String utilities (pipe-compatible)
-const slug = slugify("Hello World!"); // "hello-world"
-const slugInPipe = R.pipe("Hello World!", slugify()); // "hello-world"
+R.pipe("  <b>Hello World!</b>  ", R.sanitizeString(), R.slugify());
+// "hello-world"
 
-// With options
-const customSlug = slugify("Hello World!", { maxLength: 5, separator: "_" }); // "hello"
-
-// Sanitize strings
-const clean = sanitizeString("  <script>alert('xss')</script>Hello  ");
-
-// UUID utilities
-const id = generateUuid();
-const valid = isUuid(id); // true
+const id = generateUUID();
+isUUID(id); // true
 ```
 
-## API
-
-### Remeda (`R`)
-
-Full re-export of [remeda](https://remedajs.com/). See the [remeda documentation](https://remedajs.com/docs/) for all available functions.
-
-### String Utilities
-
-#### `slugify(data, options?)` / `slugify(options?)`
-
-Convert a string to a URL-safe slug. Pipe-compatible with remeda.
-
-**Options:**
-
-- `maxLength?: number` - Maximum length of the slug (default: 100)
-- `separator?: string` - Separator character (default: "-")
-
-#### `sanitizeString(data, options?)` / `sanitizeString(options?)`
-
-Sanitize a string by removing HTML and normalizing Unicode. Pipe-compatible with remeda.
-
-**Options:**
-
-- `trim?: boolean` - Trim whitespace (default: true)
-
-#### `isNullishOrEmptyString(value)`
-
-Type guard that returns true if the value is null, undefined, or an empty string.
-
-### UUID Utilities
-
-#### `generateUuid()`
-
-Generate a new UUIDv4 string.
-
-#### `isUuid(value)`
-
-Type guard that returns true if the value is a valid UUID string.
+See the [remeda documentation](https://remedajs.com/docs/) for the full `R.*` surface, and the inline TSDoc for option shapes and UUID version overloads.
 
 ## License
 

--- a/packages/toolkit/src/remeda.spec.ts
+++ b/packages/toolkit/src/remeda.spec.ts
@@ -28,4 +28,20 @@ describe("remeda.ts", () => {
 			expect(R.unique([1, 2, 2, 3])).toEqual([1, 2, 3]);
 		});
 	});
+
+	describe("toolkit-augmented utilities", () => {
+		it("chains R.sanitizeString and R.slugify in a pipe", () => {
+			expect(
+				R.pipe("  <b>Hello World!</b>  ", R.sanitizeString(), R.slugify()),
+			).toBe("hello-world");
+		});
+
+		it("exposes R.isUUID and R.isNullishOrEmptyString as guards", () => {
+			expect(R.isUUID("550e8400-e29b-41d4-a716-446655440000")).toBe(true);
+			expect(R.isUUID("not-a-uuid")).toBe(false);
+
+			expect(R.isNullishOrEmptyString("")).toBe(true);
+			expect(R.isNullishOrEmptyString("hello")).toBe(false);
+		});
+	});
 });

--- a/packages/toolkit/src/remeda.ts
+++ b/packages/toolkit/src/remeda.ts
@@ -1,14 +1,27 @@
+import * as remeda from "remeda";
+
+import { isNullishOrEmptyString } from "./string/guards";
+import { sanitizeString } from "./string/sanitize.remeda";
+import { slugify } from "./string/slugify.remeda";
+import { isUUID } from "./uuid/is-uuid";
+
 /**
- * Re-export remeda as R for convenient access to functional utilities.
+ * Remeda re-export augmented with toolkit's remeda-compatible utilities.
+ *
+ * Exposes every function from `remeda` (see https://remedajs.com/docs/)
+ * alongside data-last / pipe-friendly variants of toolkit helpers.
  *
  * @example
  * ```typescript
  * import { R } from '@abinnovision/nestjs-toolkit';
  *
- * const doubled = R.pipe([1, 2, 3], R.map(x => x * 2));
- * const unique = R.unique([1, 2, 2, 3]);
+ * R.pipe("  <b>Hello World!</b>  ", R.sanitizeString(), R.slugify()); // "hello-world"
  * ```
- *
- * @see https://remedajs.com/docs/ for full documentation
  */
-export * as R from "remeda";
+export const R = {
+	...remeda,
+	slugify,
+	sanitizeString,
+	isUUID,
+	isNullishOrEmptyString,
+} as const;

--- a/packages/toolkit/src/string/sanitize.remeda.spec.ts
+++ b/packages/toolkit/src/string/sanitize.remeda.spec.ts
@@ -1,0 +1,20 @@
+import { pipe } from "remeda";
+import { describe, expect, it } from "vitest";
+
+import { sanitizeString } from "./sanitize.remeda";
+
+describe("string/sanitize.remeda.ts", () => {
+	describe("#sanitizeString()", () => {
+		it("sanitizes with defaults when no options are given", () => {
+			expect(
+				pipe("<script>alert('xss')</script>Hello   World", sanitizeString()),
+			).toBe("Hello World");
+		});
+
+		it("forwards options to the underlying sanitizeString", () => {
+			expect(pipe("  Hello  ", sanitizeString({ trim: false }))).toBe(
+				" Hello ",
+			);
+		});
+	});
+});

--- a/packages/toolkit/src/string/sanitize.remeda.ts
+++ b/packages/toolkit/src/string/sanitize.remeda.ts
@@ -1,0 +1,24 @@
+import { sanitizeString as sanitizeStringDirect } from "./sanitize";
+
+import type { SanitizeOptions } from "./sanitize";
+
+/**
+ * Remeda-compatible (data-last) variant of `sanitizeString`.
+ *
+ * Returns a function that, given a string, produces a sanitized copy with
+ * HTML tags removed and whitespace normalized. Designed to be used inside
+ * `R.pipe(...)` and exposed as `R.sanitizeString`.
+ *
+ * @example
+ * ```typescript
+ * import { R } from '@abinnovision/nestjs-toolkit';
+ *
+ * R.pipe("<script>alert('xss')</script>Hello", R.sanitizeString()); // "Hello"
+ * R.pipe("  Hello  ", R.sanitizeString({ trim: false }));           // " Hello "
+ * ```
+ */
+export function sanitizeString(
+	options?: SanitizeOptions,
+): (data: string) => string {
+	return (data: string) => sanitizeStringDirect(data, options);
+}

--- a/packages/toolkit/src/string/sanitize.spec.ts
+++ b/packages/toolkit/src/string/sanitize.spec.ts
@@ -1,4 +1,3 @@
-import { pipe } from "remeda";
 import { describe, expect, it } from "vitest";
 
 import { sanitizeString } from "./sanitize";
@@ -29,18 +28,6 @@ describe("string/sanitize.ts", () => {
 
 		it("respects trim: false option", () => {
 			expect(sanitizeString("  Hello  ", { trim: false })).toBe(" Hello ");
-		});
-
-		it("works with remeda pipe (data-last)", () => {
-			const result = pipe("<b>Hello</b>  World", sanitizeString());
-
-			expect(result).toBe("Hello World");
-		});
-
-		it("works with remeda pipe and options (data-last)", () => {
-			const result = pipe("  Hello  ", sanitizeString({ trim: false }));
-
-			expect(result).toBe(" Hello ");
 		});
 
 		it("handles empty string", () => {

--- a/packages/toolkit/src/string/sanitize.ts
+++ b/packages/toolkit/src/string/sanitize.ts
@@ -10,9 +10,18 @@ export interface SanitizeOptions {
 }
 
 /**
- * Implementation of the sanitizeString function.
+ * Sanitize a string by removing HTML tags and normalizing whitespace.
+ *
+ * For remeda-compatible (data-last / pipe-friendly) usage, use
+ * `R.sanitizeString(opts?)` from the `R` namespace instead.
+ *
+ * @example
+ * ```typescript
+ * sanitizeString("  <b>Hello</b>  World  ");     // "Hello World"
+ * sanitizeString("  Hello  ", { trim: false }); // " Hello "
+ * ```
  */
-function sanitizeStringImpl(
+export function sanitizeString(
 	data: string,
 	options: SanitizeOptions = {},
 ): string {
@@ -34,40 +43,4 @@ function sanitizeStringImpl(
 	}
 
 	return result;
-}
-
-/**
- * Sanitize a string by removing HTML tags and normalizing whitespace.
- *
- * This function is pipe-compatible with remeda, supporting both data-first
- * and data-last calling styles.
- *
- * @example Data-first (direct call)
- * ```typescript
- * sanitizeString("  <b>Hello</b>  World  "); // "Hello World"
- * sanitizeString("  Hello  ", { trim: false }); // " Hello "
- * ```
- *
- * @example Data-last (in pipes)
- * ```typescript
- * import { R } from '@abinnovision/nestjs-toolkit';
- *
- * R.pipe("<script>alert('xss')</script>Hello", sanitizeString()); // "Hello"
- * ```
- */
-export function sanitizeString(
-	options?: SanitizeOptions,
-): (data: string) => string;
-export function sanitizeString(data: string, options?: SanitizeOptions): string;
-export function sanitizeString(
-	dataOrOptions?: string | SanitizeOptions,
-	options?: SanitizeOptions,
-): string | ((data: string) => string) {
-	// Data-last: called with no args or with options object
-	if (dataOrOptions === undefined || typeof dataOrOptions === "object") {
-		return (data: string) => sanitizeStringImpl(data, dataOrOptions);
-	}
-
-	// Data-first: called with string data
-	return sanitizeStringImpl(dataOrOptions, options);
 }

--- a/packages/toolkit/src/string/slugify.remeda.spec.ts
+++ b/packages/toolkit/src/string/slugify.remeda.spec.ts
@@ -1,0 +1,19 @@
+import { pipe } from "remeda";
+import { describe, expect, it } from "vitest";
+
+import { slugify } from "./slugify.remeda";
+
+describe("string/slugify.remeda.ts", () => {
+	describe("#slugify()", () => {
+		it("slugifies with defaults when no options are given", () => {
+			expect(pipe("Hello World!", slugify())).toBe("hello-world");
+		});
+
+		it("forwards options to the underlying slugify", () => {
+			expect(pipe("Hello World!", slugify({ separator: "_" }))).toBe(
+				"hello_world",
+			);
+			expect(pipe("Hello World!", slugify({ maxLength: 5 }))).toBe("hello");
+		});
+	});
+});

--- a/packages/toolkit/src/string/slugify.remeda.ts
+++ b/packages/toolkit/src/string/slugify.remeda.ts
@@ -1,0 +1,21 @@
+import { slugify as slugifyDirect } from "./slugify";
+
+import type { SlugifyOptions } from "./slugify";
+
+/**
+ * Remeda-compatible (data-last) variant of `slugify`.
+ *
+ * Returns a function that, given a string, produces its URL-safe slug.
+ * Designed to be used inside `R.pipe(...)` and exposed as `R.slugify`.
+ *
+ * @example
+ * ```typescript
+ * import { R } from '@abinnovision/nestjs-toolkit';
+ *
+ * R.pipe("Hello World!", R.slugify());                   // "hello-world"
+ * R.pipe("Hello World!", R.slugify({ separator: "_" })); // "hello_world"
+ * ```
+ */
+export function slugify(options?: SlugifyOptions): (data: string) => string {
+	return (data: string) => slugifyDirect(data, options);
+}

--- a/packages/toolkit/src/string/slugify.spec.ts
+++ b/packages/toolkit/src/string/slugify.spec.ts
@@ -1,4 +1,3 @@
-import { pipe } from "remeda";
 import { describe, expect, it } from "vitest";
 
 import { slugify } from "./slugify";
@@ -31,18 +30,6 @@ describe("string/slugify.ts", () => {
 
 		it("respects separator option", () => {
 			expect(slugify("Hello World", { separator: "_" })).toBe("hello_world");
-		});
-
-		it("works with remeda pipe (data-last)", () => {
-			const result = pipe("Hello World!", slugify());
-
-			expect(result).toBe("hello-world");
-		});
-
-		it("works with remeda pipe and options (data-last)", () => {
-			const result = pipe("Hello World!", slugify({ maxLength: 5 }));
-
-			expect(result).toBe("hello");
 		});
 
 		it("handles empty string", () => {

--- a/packages/toolkit/src/string/slugify.ts
+++ b/packages/toolkit/src/string/slugify.ts
@@ -16,9 +16,18 @@ export interface SlugifyOptions {
 }
 
 /**
- * Implementation of the slugify function.
+ * Convert a string to a URL-safe slug.
+ *
+ * For remeda-compatible (data-last / pipe-friendly) usage, use
+ * `R.slugify(opts?)` from the `R` namespace instead.
+ *
+ * @example
+ * ```typescript
+ * slugify("Hello World!");                   // "hello-world"
+ * slugify("Hello World!", { maxLength: 5 }); // "hello"
+ * ```
  */
-function slugifyImpl(data: string, options: SlugifyOptions = {}): string {
+export function slugify(data: string, options: SlugifyOptions = {}): string {
 	const { maxLength = 100, separator = "-" } = options;
 
 	return (
@@ -28,7 +37,7 @@ function slugifyImpl(data: string, options: SlugifyOptions = {}): string {
 			// Normalize Unicode characters (decompose accented characters)
 			.normalize("NFD")
 			// Remove diacritical marks
-			.replace(/[\u0300-\u036f]/g, "")
+			.replace(/[̀-ͯ]/g, "")
 			// Replace any non-alphanumeric characters with the separator
 			.replace(/[^a-z0-9]+/g, separator)
 			// Remove leading/trailing separators
@@ -36,39 +45,4 @@ function slugifyImpl(data: string, options: SlugifyOptions = {}): string {
 			// Truncate to max length
 			.slice(0, maxLength)
 	);
-}
-
-/**
- * Convert a string to a URL-safe slug.
- *
- * This function is pipe-compatible with remeda, supporting both data-first
- * and data-last calling styles.
- *
- * @example Data-first (direct call)
- * ```typescript
- * slugify("Hello World!"); // "hello-world"
- * slugify("Hello World!", { maxLength: 5 }); // "hello"
- * ```
- *
- * @example Data-last (in pipes)
- * ```typescript
- * import { R } from '@abinnovision/nestjs-toolkit';
- *
- * R.pipe("Hello World!", slugify()); // "hello-world"
- * R.pipe("Hello World!", slugify({ separator: "_" })); // "hello_world"
- * ```
- */
-export function slugify(options?: SlugifyOptions): (data: string) => string;
-export function slugify(data: string, options?: SlugifyOptions): string;
-export function slugify(
-	dataOrOptions?: string | SlugifyOptions,
-	options?: SlugifyOptions,
-): string | ((data: string) => string) {
-	// Data-last: called with no args or with options object
-	if (dataOrOptions === undefined || typeof dataOrOptions === "object") {
-		return (data: string) => slugifyImpl(data, dataOrOptions);
-	}
-
-	// Data-first: called with string data
-	return slugifyImpl(dataOrOptions, options);
 }


### PR DESCRIPTION
## Summary

- Default `slugify` and `sanitizeString` are now single-signature, data-first only (overloads and the runtime `dataOrOptions` branching are gone), so the public helpers do one thing each.
- New `*.remeda.ts` wrappers provide curried, pipe-friendly variants that are merged into `R` alongside the full remeda re-export, giving `R.slugify`, `R.sanitizeString`, `R.isUUID`, and `R.isNullishOrEmptyString` — `generateUUID` is intentionally omitted (no data input).
- Specs split accordingly: direct-call specs stay with the data-first files, new `*.remeda.spec.ts` files cover the curried wrappers via `R.pipe`, and `remeda.spec.ts` is extended with a `toolkit-augmented utilities` block.
- README trimmed to a minimal surface that documents the two entry points and points at remeda docs / inline TSDoc for the rest.

## Test plan

- [x] `yarn workspace @abinnovision/nestjs-toolkit test-unit` — 9 files / 66 tests passing, 100% coverage
- [x] `yarn workspace @abinnovision/nestjs-toolkit build` — clean
- [x] `yarn workspace @abinnovision/nestjs-toolkit lint:check` / `format:check` — clean