### PR TITLE
feat(healthz): add self-mounting health check module

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,7 @@
 	"packages/configx": "2.0.4",
 	"packages/exceptions": "0.0.1",
 	"packages/hatchet": "0.6.1",
+	"packages/healthz": "0.0.0",
 	"packages/toolkit": "0.0.1",
 	"apps/docs": "0.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ A collection of common packages for NestJS.
 
 ## Packages
 
-| Package                                             | Version                                                                                                                                           | Description                                                             |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| [`@abinnovision/nestjs-configx`](/packages/configx) | [![npm](https://img.shields.io/npm/v/@abinnovision/nestjs-configx?style=flat-square)](https://www.npmjs.com/package/@abinnovision/nestjs-configx) | Simple configuration management for NestJS, supporting Standard Schema. |
-| [`@abinnovision/nestjs-hatchet`](/packages/hatchet) | [![npm](https://img.shields.io/npm/v/@abinnovision/nestjs-hatchet?style=flat-square)](https://www.npmjs.com/package/@abinnovision/nestjs-hatchet) | NestJS integration for Hatchet workflow orchestration.                  |
+| Package                                             | Version                                                                                                                                           | Description                                                                                         |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| [`@abinnovision/nestjs-configx`](/packages/configx) | [![npm](https://img.shields.io/npm/v/@abinnovision/nestjs-configx?style=flat-square)](https://www.npmjs.com/package/@abinnovision/nestjs-configx) | Simple configuration management for NestJS, supporting Standard Schema.                             |
+| [`@abinnovision/nestjs-hatchet`](/packages/hatchet) | [![npm](https://img.shields.io/npm/v/@abinnovision/nestjs-hatchet?style=flat-square)](https://www.npmjs.com/package/@abinnovision/nestjs-hatchet) | NestJS integration for Hatchet workflow orchestration.                                              |
+| [`@abinnovision/nestjs-healthz`](/packages/healthz) | [![npm](https://img.shields.io/npm/v/@abinnovision/nestjs-healthz?style=flat-square)](https://www.npmjs.com/package/@abinnovision/nestjs-healthz) | Self-mounting health check module with cross-module attestor discovery and Kubernetes-style probes. |
 
 See each package README for installation and usage instructions.
 

--- a/packages/healthz/README.md
+++ b/packages/healthz/README.md
@@ -1,0 +1,229 @@
+# @abinnovision/nestjs-healthz
+
+Self-mounting health check module for NestJS. Mounts Kubernetes-style
+`/livez`, `/readyz`, and `/healthz` endpoints, and discovers health
+attestors decorated across the application — no central registry,
+no per-module wiring.
+
+## Installation
+
+```bash
+yarn add @abinnovision/nestjs-healthz
+```
+
+## Quick Start
+
+### 1. Mount the module
+
+```typescript
+import { HealthzModule } from "@abinnovision/nestjs-healthz";
+
+@Module({
+  imports: [DatabaseModule, HealthzModule.forRoot({})],
+})
+export class AppModule {}
+```
+
+`HealthzModule.forRoot({})` is global — every module that loads into
+the app graph is scanned for attestors.
+
+### 2. Declare an attestor inside the module that owns the dependency
+
+```typescript
+import {
+  HealthAttestor,
+  type HealthCheckOutcome,
+} from "@abinnovision/nestjs-healthz";
+
+@HealthAttestor({ name: "database", critical: true })
+export class DatabaseAttestor implements HealthAttestor {
+  public constructor(private readonly db: DatabaseService) {}
+
+  public async check(): Promise<HealthCheckOutcome> {
+    await this.db.query("SELECT 1");
+    return { status: "ok" };
+  }
+}
+```
+
+`@HealthAttestor()` applies `@Injectable()` internally — the same way
+`@Controller()` and `@Resolver()` do — so no need to also write
+`@Injectable()`. The class still needs to be registered as a provider:
+
+```typescript
+@Module({
+  providers: [DatabaseService, DatabaseAttestor],
+})
+export class DatabaseModule {}
+```
+
+That's it. `/healthz`, `/readyz`, and `/livez` are live.
+
+## Endpoints
+
+| Path           | Behavior                                                         | Use case                                          |
+| -------------- | ---------------------------------------------------------------- | ------------------------------------------------- |
+| `GET /livez`   | Returns `200 { status, timestamp }`. Runs **no** attestors.      | Kubernetes liveness probe — "process is alive".   |
+| `GET /readyz`  | Runs every discovered attestor and returns the aggregate status. | Kubernetes readiness probe — "ready for traffic". |
+| `GET /healthz` | Alias of `/readyz`.                                              | Canonical "is the application healthy?" name.     |
+
+`/livez` intentionally runs no attestors so that a slow downstream
+dependency cannot trigger pod restarts. Wire only `/readyz` (or
+`/healthz`) to readiness checks that gate traffic.
+
+## Status model
+
+The aggregate status is three-state:
+
+| Aggregate    | HTTP | Trigger                                                       |
+| ------------ | ---- | ------------------------------------------------------------- |
+| `"ok"`       | 200  | All attestors reported `ok`.                                  |
+| `"degraded"` | 200  | Only **non-critical** attestors failed.                       |
+| `"down"`     | 503  | At least one attestor with `critical: true` (default) failed. |
+
+Each attestor declares whether it is critical:
+
+```typescript
+@HealthAttestor({ name: "queue-depth", critical: false })
+```
+
+Non-critical attestors are still reported, but their failure does not
+take traffic away.
+
+## Rate-limiting check execution
+
+Each attestor may declare a minimum interval between actual
+executions. There is no rate-limit by default — every request runs
+every check.
+
+```typescript
+@HealthAttestor({
+  name: "redis",
+  minIntervalMs: 10_000,
+})
+```
+
+The previous outcome — including a previous `down` outcome — is
+reused for requests that arrive within `minIntervalMs` of the last
+execution. The next request after the interval elapses triggers a
+fresh check.
+
+This is primarily a guard against probe traffic flooding the
+underlying subsystem. `/readyz` is typically polled by liveness
+controllers, load balancers, and dashboards in parallel; without
+`minIntervalMs`, a misconfigured client can turn that into a steady
+stream of `SELECT 1` queries against your database. The bound is
+process-local — each replica enforces its own rate.
+
+## Timeouts and thrown errors
+
+`check()` is bounded by a per-attestor timeout (default 2000 ms). A
+timed-out check is reported as `{ "status": "down" }`. Exceptions
+thrown by `check()` are caught inside the runner and produce the same
+outcome — no exception ever escapes the controller.
+
+The underlying error message is logged via the NestJS logger for
+operator diagnostics but is intentionally **not** included in the
+probe response, so a misbehaving subsystem cannot leak internal error
+text to whoever curls `/readyz`.
+
+```typescript
+@HealthAttestor({ name: "slow-api", timeoutMs: 5000 })
+```
+
+## Response shape
+
+Default response (`detail: "full"`):
+
+```json
+{
+  "status": "ok",
+  "checks": [
+    {
+      "name": "database",
+      "status": "ok",
+      "critical": true,
+      "durationMs": 12,
+      "cached": false
+    },
+    {
+      "name": "redis",
+      "status": "down",
+      "critical": false,
+      "durationMs": 2003,
+      "cached": false
+    }
+  ],
+  "timestamp": "2026-05-13T12:34:56.000Z"
+}
+```
+
+The detail level is configurable via `HealthzModule.forRoot()`:
+
+```typescript
+HealthzModule.forRoot({ detail: "summary" });
+```
+
+| `detail`    | Body                                                     |
+| ----------- | -------------------------------------------------------- |
+| `"full"`    | Aggregate status + per-attestor breakdown (default).     |
+| `"summary"` | `{ status, timestamp }` only.                            |
+| `"none"`    | Empty body — clients rely on the HTTP status code alone. |
+
+The HTTP status code is identical across detail modes.
+
+## API
+
+### `HealthzModule.forRoot(config)`
+
+Registers the module globally and mounts the three endpoints.
+
+```typescript
+HealthzModule.forRoot({ detail: "full" });
+```
+
+### `@HealthAttestor(options)`
+
+Marks a class as a health attestor. The class must implement `check()`
+returning `HealthCheckOutcome` (sync or async). Internally applies
+`@Injectable()`.
+
+```typescript
+interface HealthAttestorOptions {
+  name: string;
+  critical?: boolean; // default true
+  minIntervalMs?: number; // when set, check runs at most once per interval
+  timeoutMs?: number; // default 2000
+}
+```
+
+### `HealthAttestor` (interface)
+
+The contract every attestor must satisfy. Shares its name with the
+decorator function — TypeScript's separate value and type namespaces
+let `@HealthAttestor(...)` and `implements HealthAttestor` coexist.
+
+```typescript
+interface HealthAttestor {
+  check(): Promise<HealthCheckOutcome> | HealthCheckOutcome;
+}
+```
+
+### `HealthCheckOutcome`
+
+```typescript
+interface HealthCheckOutcome {
+  status: "ok" | "down";
+  details?: Record<string, string>;
+}
+```
+
+`details` is surfaced in `detail: "full"` responses — useful for
+small, safe-to-publish diagnostics (e.g. `{ "lag_seconds": "12" }`).
+Values are restricted to strings so the response stays predictable
+and no caller can accidentally publish unbounded objects or sensitive
+fields.
+
+## License
+
+Apache-2.0

--- a/packages/healthz/eslint.config.mjs
+++ b/packages/healthz/eslint.config.mjs
@@ -1,0 +1,7 @@
+import { base, configFiles, vitest } from "@abinnovision/eslint-config-base";
+import { defineConfig } from "eslint/config";
+
+export default defineConfig([
+	{ extends: [base, vitest] },
+	{ files: ["*.{c,m,}{t,j}s"], extends: [configFiles] },
+]);

--- a/packages/healthz/package.json
+++ b/packages/healthz/package.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/package.json",
 	"name": "@abinnovision/nestjs-healthz",
-	"version": "0.0.1",
+	"version": "0.0.0",
 	"description": "Self-mounting health check module for NestJS with cross-module attestor discovery, per-attestor caching, and Kubernetes-style /livez and /readyz endpoints.",
 	"keywords": [
 		"nestjs",

--- a/packages/healthz/package.json
+++ b/packages/healthz/package.json
@@ -1,0 +1,77 @@
+{
+	"$schema": "https://json.schemastore.org/package.json",
+	"name": "@abinnovision/nestjs-healthz",
+	"version": "0.0.1",
+	"description": "Self-mounting health check module for NestJS with cross-module attestor discovery, per-attestor caching, and Kubernetes-style /livez and /readyz endpoints.",
+	"keywords": [
+		"nestjs",
+		"healthz",
+		"health-check",
+		"liveness",
+		"readiness",
+		"kubernetes",
+		"observability"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/abinnovision/nestjs-commons.git",
+		"directory": "packages/healthz"
+	},
+	"license": "Apache-2.0",
+	"author": {
+		"name": "abi group GmbH",
+		"email": "info@abigroup.io",
+		"url": "https://abigroup.io"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"require": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist",
+		"LICENSE",
+		"README.md"
+	],
+	"scripts": {
+		"build": "tsc --project tsconfig.build.json",
+		"format:check": "prettier --check 'src/**/*.ts' '*.{json{,5},md,y{,a}ml}'",
+		"format:fix": "prettier --write 'src/**/*.ts' '*.{json{,5},md,y{,a}ml}'",
+		"lint:check": "eslint 'src/**/*.ts'",
+		"lint:fix": "eslint 'src/**/*.ts' --fix",
+		"test-unit": "vitest --run --coverage --config vitest.config.mts",
+		"test-unit:watch": "vitest --config vitest.config.mts"
+	},
+	"lint-staged": {
+		"src/**/*.ts": [
+			"eslint --fix",
+			"prettier --write"
+		],
+		"*.{json{,5},md,y{,a}ml}": "prettier --write"
+	},
+	"prettier": "@abinnovision/prettier-config",
+	"devDependencies": {
+		"@abinnovision/eslint-config-base": "^3.4.1",
+		"@abinnovision/prettier-config": "^2.2.0",
+		"@nestjs/common": "^11.0.0",
+		"@nestjs/core": "^11.0.0",
+		"@swc/core": "^1.11.5",
+		"eslint": "^10.3.0",
+		"prettier": "^3.8.3",
+		"reflect-metadata": "^0.2.2",
+		"rxjs": "^7.8.1",
+		"typescript": "^5.8.2",
+		"vitest": "^4.0.15"
+	},
+	"peerDependencies": {
+		"@nestjs/common": "^11.0.0",
+		"@nestjs/core": "^11.0.0"
+	},
+	"publishConfig": {
+		"ghpr": true,
+		"npm": true,
+		"npmAccess": "public"
+	}
+}

--- a/packages/healthz/src/cache/attestor-cache.spec.ts
+++ b/packages/healthz/src/cache/attestor-cache.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { AttestorCache } from "./attestor-cache";
+
+import type { HealthCheckOutcome } from "../health-attestor";
+
+const okOutcome: HealthCheckOutcome = { status: "ok" };
+
+describe("cache/attestor-cache.ts", () => {
+	describe("attestorCache", () => {
+		it("returns undefined for an unknown name", () => {
+			const cache = new AttestorCache();
+
+			expect(cache.get("missing")).toBeUndefined();
+		});
+
+		it("returns the stored snapshot before the TTL elapses", () => {
+			let now = 1000;
+			const cache = new AttestorCache(() => now);
+
+			cache.set("db", { outcome: okOutcome, durationMs: 12 }, 5000);
+			now = 4999;
+
+			expect(cache.get("db")).toEqual({ outcome: okOutcome, durationMs: 12 });
+		});
+
+		it("evicts and returns undefined once the TTL elapses", () => {
+			let now = 1000;
+			const cache = new AttestorCache(() => now);
+
+			cache.set("db", { outcome: okOutcome, durationMs: 12 }, 5000);
+			now = 6001;
+
+			expect(cache.get("db")).toBeUndefined();
+		});
+
+		it("ignores a non-positive TTL", () => {
+			const cache = new AttestorCache();
+
+			cache.set("db", { outcome: okOutcome, durationMs: 12 }, 0);
+			cache.set("db", { outcome: okOutcome, durationMs: 12 }, -1);
+
+			expect(cache.get("db")).toBeUndefined();
+		});
+
+		it("caches a `down` outcome when the consumer opted in", () => {
+			let now = 1000;
+			const cache = new AttestorCache(() => now);
+			const downOutcome: HealthCheckOutcome = { status: "down" };
+
+			cache.set("db", { outcome: downOutcome, durationMs: 7 }, 5000);
+			now = 1500;
+
+			expect(cache.get("db")).toEqual({
+				outcome: downOutcome,
+				durationMs: 7,
+			});
+		});
+	});
+});

--- a/packages/healthz/src/cache/attestor-cache.ts
+++ b/packages/healthz/src/cache/attestor-cache.ts
@@ -1,0 +1,72 @@
+import type { HealthCheckOutcome } from "../health-attestor";
+
+interface CachedEntry {
+	outcome: HealthCheckOutcome;
+	durationMs: number;
+	expiresAt: number;
+}
+
+/**
+ * Snapshot returned for a cache hit. `durationMs` is the duration of
+ * the original check (the cache lookup itself is effectively
+ * instantaneous).
+ */
+export interface CachedSnapshot {
+	outcome: HealthCheckOutcome;
+	durationMs: number;
+}
+
+/**
+ * Simple in-memory TTL cache for attestor outcomes.
+ *
+ * Keyed by attestor name. Entries expire after their TTL elapses; the
+ * next read after expiry returns `undefined` so the caller can re-run
+ * the underlying check.
+ *
+ * The cache is process-local — no external store, no synchronisation
+ * across replicas. Each pod evaluates its own health independently.
+ */
+export class AttestorCache {
+	private readonly entries = new Map<string, CachedEntry>();
+	private readonly clock: () => number;
+
+	public constructor(clock?: () => number) {
+		this.clock = clock ?? ((): number => Date.now());
+	}
+
+	/**
+	 * Returns the cached snapshot for `name` if still fresh; otherwise
+	 * evicts the stale entry and returns `undefined`.
+	 */
+	public get(name: string): CachedSnapshot | undefined {
+		const entry = this.entries.get(name);
+
+		if (entry === undefined) {
+			return undefined;
+		}
+
+		if (entry.expiresAt <= this.clock()) {
+			this.entries.delete(name);
+
+			return undefined;
+		}
+
+		return { outcome: entry.outcome, durationMs: entry.durationMs };
+	}
+
+	/**
+	 * Stores `snapshot` under `name`, evicting it again after `ttlMs`.
+	 * A non-positive `ttlMs` is a no-op.
+	 */
+	public set(name: string, snapshot: CachedSnapshot, ttlMs: number): void {
+		if (ttlMs <= 0) {
+			return;
+		}
+
+		this.entries.set(name, {
+			outcome: snapshot.outcome,
+			durationMs: snapshot.durationMs,
+			expiresAt: this.clock() + ttlMs,
+		});
+	}
+}

--- a/packages/healthz/src/explorer/attestor-explorer.service.spec.ts
+++ b/packages/healthz/src/explorer/attestor-explorer.service.spec.ts
@@ -1,0 +1,117 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+
+import { HealthAttestor } from "../health-attestor";
+import { AttestorExplorer } from "./attestor-explorer.service";
+
+import type {
+	HealthAttestor as HealthAttestorContract,
+	HealthCheckOutcome,
+} from "../health-attestor";
+import type { DiscoveryService } from "@nestjs/core";
+
+interface FakeProvider {
+	instance: unknown;
+	metatype: unknown;
+}
+
+const stubDiscovery = (providers: FakeProvider[]): DiscoveryService =>
+	({
+		getProviders: (): FakeProvider[] => providers,
+	}) as unknown as DiscoveryService;
+
+describe("explorer/attestor-explorer.service.ts", () => {
+	describe("attestorExplorer.onApplicationBootstrap()", () => {
+		it("collects providers decorated with @HealthAttestor()", () => {
+			@HealthAttestor({ name: "db" })
+			class Db implements HealthAttestorContract {
+				public check(): HealthCheckOutcome {
+					return { status: "ok" };
+				}
+			}
+
+			@HealthAttestor({ name: "redis", critical: false })
+			class Redis implements HealthAttestorContract {
+				public check(): HealthCheckOutcome {
+					return { status: "ok" };
+				}
+			}
+
+			const dbInstance = new Db();
+			const redisInstance = new Redis();
+			const explorer = new AttestorExplorer(
+				stubDiscovery([
+					{ instance: dbInstance, metatype: Db },
+					{ instance: redisInstance, metatype: Redis },
+				]),
+			);
+
+			explorer.onApplicationBootstrap();
+			const all = explorer.getAll();
+
+			expect(all).toHaveLength(2);
+			expect(all[0]?.options.name).toBe("db");
+			expect(all[0]?.instance).toBe(dbInstance);
+			expect(all[1]?.options).toEqual({ name: "redis", critical: false });
+			expect(all[1]?.instance).toBe(redisInstance);
+		});
+
+		it("skips providers without @HealthAttestor() metadata", () => {
+			class Plain {
+				public check(): HealthCheckOutcome {
+					return { status: "ok" };
+				}
+			}
+
+			const explorer = new AttestorExplorer(
+				stubDiscovery([{ instance: new Plain(), metatype: Plain }]),
+			);
+
+			explorer.onApplicationBootstrap();
+
+			expect(explorer.getAll()).toHaveLength(0);
+		});
+
+		it("skips providers with no instance (deferred / failed)", () => {
+			@HealthAttestor({ name: "deferred" })
+			class Deferred implements HealthAttestorContract {
+				public check(): HealthCheckOutcome {
+					return { status: "ok" };
+				}
+			}
+
+			const explorer = new AttestorExplorer(
+				stubDiscovery([{ instance: null, metatype: Deferred }]),
+			);
+
+			explorer.onApplicationBootstrap();
+
+			expect(explorer.getAll()).toHaveLength(0);
+		});
+
+		it("skips providers without a metatype (factory-only providers)", () => {
+			const explorer = new AttestorExplorer(
+				stubDiscovery([{ instance: { check: () => null }, metatype: null }]),
+			);
+
+			explorer.onApplicationBootstrap();
+
+			expect(explorer.getAll()).toHaveLength(0);
+		});
+
+		it("warns and skips a decorated class missing check()", () => {
+			@HealthAttestor({ name: "broken" })
+			class Broken {
+				public notACheck(): void {}
+			}
+
+			const explorer = new AttestorExplorer(
+				stubDiscovery([{ instance: new Broken(), metatype: Broken }]),
+			);
+
+			explorer.onApplicationBootstrap();
+
+			expect(explorer.getAll()).toHaveLength(0);
+		});
+	});
+});

--- a/packages/healthz/src/explorer/attestor-explorer.service.ts
+++ b/packages/healthz/src/explorer/attestor-explorer.service.ts
@@ -1,0 +1,98 @@
+import { Injectable, Logger, OnApplicationBootstrap } from "@nestjs/common";
+import { DiscoveryService } from "@nestjs/core";
+
+import { METADATA_KEY_HEALTH_ATTESTOR } from "../metadata/keys";
+
+import type { HealthAttestor, HealthAttestorOptions } from "../health-attestor";
+import type { RegisteredAttestor } from "../runner/attestor-runner.service";
+
+/**
+ * Discovers every provider annotated with `@HealthAttestor()` at
+ * application bootstrap and exposes them as a flat list to the
+ * aggregator service.
+ *
+ * Discovery uses NestJS' `DiscoveryService`, so attestors are picked
+ * up regardless of which module they live in — as long as that module
+ * is loaded into the application graph.
+ */
+@Injectable()
+export class AttestorExplorer implements OnApplicationBootstrap {
+	private static readonly LOGGER = new Logger(AttestorExplorer.name);
+
+	private readonly attestors: RegisteredAttestor[] = [];
+
+	public constructor(private readonly discovery: DiscoveryService) {}
+
+	public onApplicationBootstrap(): void {
+		const providers = this.discovery.getProviders();
+
+		for (const wrapper of providers) {
+			const { metatype } = wrapper;
+
+			if (metatype === null) {
+				continue;
+			}
+
+			const options = Reflect.getMetadata(
+				METADATA_KEY_HEALTH_ATTESTOR,
+				metatype,
+			) as HealthAttestorOptions | undefined;
+
+			if (options === undefined) {
+				continue;
+			}
+
+			const instance = wrapper.instance as HealthAttestor | undefined | null;
+
+			if (instance === undefined || instance === null) {
+				continue;
+			}
+
+			if (typeof instance.check !== "function") {
+				AttestorExplorer.LOGGER.warn(
+					`Provider '${metatype.name}' is decorated with @HealthAttestor() but does not implement check()`,
+				);
+
+				continue;
+			}
+
+			this.attestors.push({ instance, options });
+		}
+
+		this.warnOnDuplicates();
+
+		const names = this.attestors.map((a) => a.options.name).join(", ");
+		const count = this.attestors.length.toString();
+
+		AttestorExplorer.LOGGER.log(
+			`Discovered ${count} health attestor(s)${
+				names.length > 0 ? `: ${names}` : ""
+			}`,
+		);
+	}
+
+	public getAll(): readonly RegisteredAttestor[] {
+		return this.attestors;
+	}
+
+	private warnOnDuplicates(): void {
+		const seen = new Set<string>();
+		const dupes = new Set<string>();
+
+		for (const attestor of this.attestors) {
+			if (seen.has(attestor.options.name)) {
+				dupes.add(attestor.options.name);
+			}
+
+			seen.add(attestor.options.name);
+		}
+
+		if (dupes.size > 0) {
+			AttestorExplorer.LOGGER.warn(
+				`Duplicate attestor name(s) detected: ${[...dupes].join(
+					", ",
+				)}. Each will be invoked but reports may collide in dashboards.`,
+			);
+		}
+	}
+}

--- a/packages/healthz/src/health-attestor.spec.ts
+++ b/packages/healthz/src/health-attestor.spec.ts
@@ -1,0 +1,64 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+
+import { HealthAttestor } from "./health-attestor";
+import { METADATA_KEY_HEALTH_ATTESTOR } from "./metadata/keys";
+
+import type {
+	HealthAttestor as HealthAttestorContract,
+	HealthAttestorOptions,
+	HealthCheckOutcome,
+} from "./health-attestor";
+
+describe("health-attestor.ts", () => {
+	describe("@HealthAttestor()", () => {
+		it("stores its options as reflect metadata on the class", () => {
+			const options: HealthAttestorOptions = {
+				name: "database",
+				critical: true,
+				minIntervalMs: 5000,
+			};
+
+			@HealthAttestor(options)
+			class DatabaseAttestor implements HealthAttestorContract {
+				public check(): HealthCheckOutcome {
+					return { status: "ok" };
+				}
+			}
+
+			const read = Reflect.getMetadata(
+				METADATA_KEY_HEALTH_ATTESTOR,
+				DatabaseAttestor,
+			) as HealthAttestorOptions | undefined;
+
+			expect(read).toEqual(options);
+		});
+
+		it("applies @Injectable() so consumers do not have to", () => {
+			@HealthAttestor({ name: "x" })
+			class X implements HealthAttestorContract {
+				public check(): HealthCheckOutcome {
+					return { status: "ok" };
+				}
+			}
+
+			// `@Injectable()` defines both INJECTABLE_WATERMARK and
+			// SCOPE_OPTIONS_METADATA on the target. The watermark uses the
+			// literal key `"__injectable__"` internally.
+			expect(Reflect.getMetadata("__injectable__", X)).toBe(true);
+		});
+
+		it("allows the interface and decorator to share the name HealthAttestor", () => {
+			// This test compiles iff HealthAttestor is usable in both value
+			// and type positions in the same scope.
+			@HealthAttestor({ name: "shared" })
+			class Shared implements HealthAttestorContract {
+				public check(): HealthCheckOutcome {
+					return { status: "ok" };
+				}
+			}
+
+			expect(new Shared().check()).toEqual({ status: "ok" });
+		});
+	});
+});

--- a/packages/healthz/src/health-attestor.ts
+++ b/packages/healthz/src/health-attestor.ts
@@ -1,0 +1,141 @@
+import { applyDecorators, Injectable, SetMetadata } from "@nestjs/common";
+
+import { METADATA_KEY_HEALTH_ATTESTOR } from "./metadata/keys";
+
+import type { HealthStatus } from "./interfaces/health-status";
+
+/**
+ * The outcome of a single attestor's check.
+ *
+ * Attestors report only `ok` or `down` for their own subsystem; the
+ * three-state `degraded` value is derived by the aggregator when a
+ * non-critical attestor is down.
+ *
+ * Thrown exceptions in `check()` are caught by the runner and
+ * surfaced as `{ status: "down" }`. The underlying error message is
+ * logged for diagnostics but is intentionally not exposed in the
+ * outcome so that probe responses cannot leak internal error text.
+ */
+export interface HealthCheckOutcome {
+	/**
+	 * The status reported by the attestor for its own subsystem.
+	 */
+	status: Exclude<HealthStatus, "degraded">;
+
+	/**
+	 * Optional structured details surfaced in the response payload when
+	 * the configured detail level includes per-attestor information.
+	 *
+	 * Values are restricted to strings to keep the response payload
+	 * predictable and avoid accidental serialisation of unbounded
+	 * objects, errors, or non-JSON-safe values.
+	 */
+	details?: Record<string, string>;
+}
+
+/**
+ * Contract that any class decorated with `@HealthAttestor()` must
+ * implement.
+ *
+ * An attestor lives inside its source module (e.g. `DatabaseModule`)
+ * and has full DI access to the services it needs to probe.
+ */
+export interface HealthAttestor {
+	/**
+	 * Probe the subsystem and return its current health.
+	 *
+	 * Implementations should resolve within the configured per-attestor
+	 * timeout. Thrown exceptions are caught by the runner and converted
+	 * to `{ status: "down" }`, so raising an error is a valid way to
+	 * signal a failed check — the error message is logged for
+	 * diagnostics but not included in the probe response.
+	 */
+	check: () => Promise<HealthCheckOutcome> | HealthCheckOutcome;
+}
+
+/**
+ * Options passed to the `@HealthAttestor()` decorator.
+ */
+export interface HealthAttestorOptions {
+	/**
+	 * Unique name for this attestor. Surfaces in the response under
+	 * `checks[].name`. Should be unique across all attestors registered
+	 * with a given `HealthzModule`; duplicates are tolerated but produce
+	 * a startup warning.
+	 */
+	name: string;
+
+	/**
+	 * Whether failure of this check should mark the overall application
+	 * as `down` (HTTP 503). Non-critical failures only mark the overall
+	 * status as `degraded` and still respond with HTTP 200.
+	 *
+	 * @default true
+	 */
+	critical?: boolean;
+
+	/**
+	 * Minimum interval between actual executions of `check()`, in
+	 * milliseconds. When set, requests that arrive sooner than this
+	 * after the previous execution receive the previous outcome rather
+	 * than triggering a new check.
+	 *
+	 * Primarily a guard against probe traffic flooding the underlying
+	 * subsystem — `/readyz` may be polled by liveness controllers,
+	 * load balancers, and dashboards simultaneously; this caps the
+	 * actual call rate to the subsystem at `1 / minIntervalMs`.
+	 *
+	 * When unset, the check runs on every request.
+	 */
+	minIntervalMs?: number;
+
+	/**
+	 * Per-attestor execution timeout in milliseconds. If `check()` does
+	 * not resolve within this window the outcome is recorded as `down`.
+	 *
+	 * @default 2000
+	 */
+	timeoutMs?: number;
+}
+
+/**
+ * A single attestor entry in the aggregated response payload.
+ */
+export interface HealthCheckReport {
+	name: string;
+	status: HealthStatus;
+	critical: boolean;
+	durationMs: number;
+	cached: boolean;
+	details?: Record<string, string>;
+}
+
+/**
+ * Marks a class as a health attestor.
+ *
+ * The decorator applies `@Injectable()` internally — matching how
+ * `@Controller()` and `@Resolver()` work in NestJS — so consumers do
+ * not need to decorate the class with `@Injectable()` separately. The
+ * class must still be listed in its owning module's `providers` array
+ * for NestJS to instantiate it.
+ *
+ * @example
+ * ```ts
+ * @HealthAttestor({ name: "database", critical: true })
+ * export class DatabaseAttestor implements HealthAttestor {
+ *   public constructor(private readonly db: DatabaseService) {}
+ *
+ *   public async check(): Promise<HealthCheckOutcome> {
+ *     await this.db.query("SELECT 1");
+ *     return { status: "ok" };
+ *   }
+ * }
+ * ```
+ */
+export const HealthAttestor = (
+	options: HealthAttestorOptions,
+): ClassDecorator =>
+	applyDecorators(
+		Injectable(),
+		SetMetadata(METADATA_KEY_HEALTH_ATTESTOR, options),
+	);

--- a/packages/healthz/src/healthz.controller.ts
+++ b/packages/healthz/src/healthz.controller.ts
@@ -1,0 +1,74 @@
+import { Controller, Get, HttpStatus, Inject, Res } from "@nestjs/common";
+
+import { HEALTHZ_MODULE_CONFIG_TOKEN } from "./healthz.module-config";
+import { HealthzService } from "./healthz.service";
+
+import type { HealthzModuleConfig } from "./healthz.module-config";
+
+/**
+ * Minimal structural shape covering both Express' `Response` and
+ * Fastify's `FastifyReply`. Both expose a `.status(code)` method
+ * returning a chainable reference, which is all this controller needs.
+ *
+ * Typing it structurally avoids pulling in a platform-specific peer
+ * dependency.
+ */
+interface ResponseLike {
+	status: (code: number) => unknown;
+}
+
+/**
+ * Self-mounted controller exposing the three Kubernetes-style probes.
+ *
+ * - `GET /livez` — process liveness; runs no attestors, always 200.
+ * - `GET /readyz` — readiness; runs every discovered attestor.
+ * - `GET /healthz` — alias of `/readyz` (provided for clarity since
+ *   the user-facing brief asked for `/healthz`).
+ */
+@Controller()
+export class HealthzController {
+	public constructor(
+		private readonly service: HealthzService,
+		@Inject(HEALTHZ_MODULE_CONFIG_TOKEN)
+		private readonly config: HealthzModuleConfig,
+	) {}
+
+	@Get("livez")
+	public livez(): { status: "ok"; timestamp: string } {
+		return { status: "ok", timestamp: new Date().toISOString() };
+	}
+
+	@Get("readyz")
+	public async readyz(
+		@Res({ passthrough: true }) res: ResponseLike,
+	): Promise<unknown> {
+		return await this.respond(res);
+	}
+
+	@Get("healthz")
+	public async healthz(
+		@Res({ passthrough: true }) res: ResponseLike,
+	): Promise<unknown> {
+		return await this.respond(res);
+	}
+
+	private async respond(res: ResponseLike): Promise<unknown> {
+		const report = await this.service.runAll();
+
+		res.status(
+			report.status === "down" ? HttpStatus.SERVICE_UNAVAILABLE : HttpStatus.OK,
+		);
+
+		const detail = this.config.detail ?? "full";
+
+		if (detail === "none") {
+			return undefined;
+		}
+
+		if (detail === "summary") {
+			return { status: report.status, timestamp: report.timestamp };
+		}
+
+		return report;
+	}
+}

--- a/packages/healthz/src/healthz.module-config.ts
+++ b/packages/healthz/src/healthz.module-config.ts
@@ -1,0 +1,30 @@
+/**
+ * Options accepted by `HealthzModule.forRoot()`.
+ *
+ * All fields are optional; calling `HealthzModule.forRoot({})` is
+ * equivalent to relying on every default.
+ */
+export interface HealthzModuleConfig {
+	/**
+	 * How much information to include in the response body.
+	 *
+	 * - `"full"` (default): full breakdown including per-attestor
+	 *   status, duration, error message, and cache state.
+	 * - `"summary"`: only the aggregate `{ status, timestamp }`.
+	 * - `"none"`: empty body — only the HTTP status code carries
+	 *   information.
+	 *
+	 * The HTTP status code is the same in all three modes: 503 when the
+	 * aggregate status is `down`, 200 otherwise.
+	 *
+	 * @default "full"
+	 */
+	detail?: "full" | "summary" | "none";
+}
+
+/**
+ * Injection token under which the resolved `HealthzModuleConfig` is
+ * provided. Exported for advanced use; most consumers do not need to
+ * reference it directly.
+ */
+export const HEALTHZ_MODULE_CONFIG_TOKEN = Symbol("healthz:module:config");

--- a/packages/healthz/src/healthz.module.ts
+++ b/packages/healthz/src/healthz.module.ts
@@ -1,0 +1,59 @@
+import { Global, Module } from "@nestjs/common";
+import { DiscoveryModule } from "@nestjs/core";
+
+import { AttestorExplorer } from "./explorer/attestor-explorer.service";
+import { HealthzController } from "./healthz.controller";
+import { HEALTHZ_MODULE_CONFIG_TOKEN } from "./healthz.module-config";
+import { HealthzService } from "./healthz.service";
+import { AttestorRunner } from "./runner/attestor-runner.service";
+
+import type { HealthzModuleConfig } from "./healthz.module-config";
+import type { DynamicModule } from "@nestjs/common";
+
+/**
+ * The healthz module — import once at the application root via
+ * `HealthzModule.forRoot({})` to mount the `/livez`, `/readyz`, and
+ * `/healthz` endpoints and enable discovery of `@HealthAttestor()`
+ * providers across the application graph.
+ *
+ * The module is registered as `global: true` so attestors declared in
+ * feature modules are automatically picked up without any of those
+ * modules needing to import `HealthzModule` themselves.
+ *
+ * @example
+ * ```ts
+ * @Module({
+ *   imports: [
+ *     DatabaseModule,
+ *     HealthzModule.forRoot({}),
+ *   ],
+ * })
+ * export class AppModule {}
+ * ```
+ */
+@Global()
+@Module({
+	imports: [DiscoveryModule],
+	controllers: [HealthzController],
+	providers: [HealthzService, AttestorExplorer, AttestorRunner],
+})
+export class HealthzModule {
+	/**
+	 * Registers the healthz module globally and binds its configuration.
+	 *
+	 * All fields of `config` are optional — `forRoot({})` is the
+	 * minimal call to accept every default.
+	 */
+	public static forRoot(config: HealthzModuleConfig): DynamicModule {
+		return {
+			module: HealthzModule,
+			global: true,
+			providers: [
+				{
+					provide: HEALTHZ_MODULE_CONFIG_TOKEN,
+					useValue: config,
+				},
+			],
+		};
+	}
+}

--- a/packages/healthz/src/healthz.service.spec.ts
+++ b/packages/healthz/src/healthz.service.spec.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+
+import { HealthzService } from "./healthz.service";
+
+import type { AttestorExplorer } from "./explorer/attestor-explorer.service";
+import type { HealthAttestor, HealthCheckOutcome } from "./health-attestor";
+import type {
+	AttestorRunner,
+	RegisteredAttestor,
+} from "./runner/attestor-runner.service";
+
+const buildRegistered = (
+	options: RegisteredAttestor["options"],
+	check?: HealthAttestor["check"],
+): RegisteredAttestor => ({
+	options,
+	instance: { check: check ?? ((): HealthCheckOutcome => ({ status: "ok" })) },
+});
+
+const stubExplorer = (attestors: RegisteredAttestor[]): AttestorExplorer =>
+	({
+		getAll: () => attestors,
+	}) as unknown as AttestorExplorer;
+
+const stubRunner = (
+	results: Map<string, { outcome: HealthCheckOutcome; durationMs: number }>,
+): AttestorRunner =>
+	({
+		execute: (attestor: RegisteredAttestor) => {
+			const result = results.get(attestor.options.name);
+
+			if (result === undefined) {
+				return Promise.reject(
+					new Error(`No stub for '${attestor.options.name}'`),
+				);
+			}
+
+			return Promise.resolve(result);
+		},
+	}) as unknown as AttestorRunner;
+
+describe("healthz.service.ts", () => {
+	describe("healthzService.runAll()", () => {
+		it("returns status 'ok' when all attestors succeed", async () => {
+			const attestors = [
+				buildRegistered({ name: "db" }),
+				buildRegistered({ name: "redis" }),
+			];
+			const results = new Map([
+				["db", { outcome: { status: "ok" } as const, durationMs: 10 }],
+				["redis", { outcome: { status: "ok" } as const, durationMs: 5 }],
+			]);
+
+			const service = new HealthzService(
+				stubExplorer(attestors),
+				stubRunner(results),
+			);
+
+			const report = await service.runAll();
+
+			expect(report.status).toBe("ok");
+			expect(report.checks).toHaveLength(2);
+			expect(report.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+		});
+
+		it("returns status 'down' when a critical attestor fails", async () => {
+			const attestors = [
+				buildRegistered({ name: "db", critical: true }),
+				buildRegistered({ name: "redis", critical: false }),
+			];
+			const results = new Map([
+				["db", { outcome: { status: "down" } as const, durationMs: 10 }],
+				["redis", { outcome: { status: "ok" } as const, durationMs: 5 }],
+			]);
+
+			const service = new HealthzService(
+				stubExplorer(attestors),
+				stubRunner(results),
+			);
+
+			const report = await service.runAll();
+
+			expect(report.status).toBe("down");
+		});
+
+		it("returns status 'degraded' when only non-critical attestors fail", async () => {
+			const attestors = [
+				buildRegistered({ name: "db", critical: true }),
+				buildRegistered({ name: "queue", critical: false }),
+			];
+			const results = new Map([
+				["db", { outcome: { status: "ok" } as const, durationMs: 10 }],
+				["queue", { outcome: { status: "down" } as const, durationMs: 7 }],
+			]);
+
+			const service = new HealthzService(
+				stubExplorer(attestors),
+				stubRunner(results),
+			);
+
+			const report = await service.runAll();
+
+			expect(report.status).toBe("degraded");
+		});
+
+		it("defaults critical to true when unset", async () => {
+			const attestors = [buildRegistered({ name: "db" })];
+			const results = new Map([
+				["db", { outcome: { status: "down" } as const, durationMs: 10 }],
+			]);
+
+			const service = new HealthzService(
+				stubExplorer(attestors),
+				stubRunner(results),
+			);
+
+			const report = await service.runAll();
+
+			expect(report.status).toBe("down");
+			expect(report.checks[0]?.critical).toBe(true);
+		});
+
+		it("rate-limits execution when minIntervalMs is set and reuses the previous outcome", async () => {
+			const attestors = [
+				buildRegistered({ name: "db", minIntervalMs: 60_000 }),
+			];
+
+			let executions = 0;
+			const runner = {
+				execute: () => {
+					executions += 1;
+
+					return Promise.resolve({
+						outcome: { status: "ok" } as const,
+						durationMs: 1,
+					});
+				},
+			} as unknown as AttestorRunner;
+
+			const service = new HealthzService(stubExplorer(attestors), runner);
+
+			const first = await service.runAll();
+			const second = await service.runAll();
+
+			expect(executions).toBe(1);
+			expect(first.checks[0]?.cached).toBe(false);
+			expect(second.checks[0]?.cached).toBe(true);
+		});
+
+		it("re-runs uncached attestors on every call", async () => {
+			const attestors = [buildRegistered({ name: "db" })];
+
+			let executions = 0;
+			const runner = {
+				execute: () => {
+					executions += 1;
+
+					return Promise.resolve({
+						outcome: { status: "ok" } as const,
+						durationMs: 1,
+					});
+				},
+			} as unknown as AttestorRunner;
+
+			const service = new HealthzService(stubExplorer(attestors), runner);
+
+			await service.runAll();
+			await service.runAll();
+
+			expect(executions).toBe(2);
+		});
+
+		it("preserves details in the report", async () => {
+			const attestors = [buildRegistered({ name: "db" })];
+			const results = new Map([
+				[
+					"db",
+					{
+						outcome: {
+							status: "down" as const,
+							details: { code: "E_DOWN", subsystem: "primary" },
+						},
+						durationMs: 10,
+					},
+				],
+			]);
+
+			const service = new HealthzService(
+				stubExplorer(attestors),
+				stubRunner(results),
+			);
+
+			const report = await service.runAll();
+
+			expect(report.checks[0]?.details).toEqual({
+				code: "E_DOWN",
+				subsystem: "primary",
+			});
+		});
+	});
+});

--- a/packages/healthz/src/healthz.service.ts
+++ b/packages/healthz/src/healthz.service.ts
@@ -1,0 +1,120 @@
+import { Injectable } from "@nestjs/common";
+
+import { AttestorCache } from "./cache/attestor-cache";
+import { AttestorExplorer } from "./explorer/attestor-explorer.service";
+import { AttestorRunner } from "./runner/attestor-runner.service";
+
+import type { HealthCheckOutcome, HealthCheckReport } from "./health-attestor";
+import type { HealthStatus } from "./interfaces/health-status";
+import type { RegisteredAttestor } from "./runner/attestor-runner.service";
+
+/**
+ * The aggregate report served by `/readyz` and `/healthz`.
+ */
+export interface AggregateReport {
+	status: HealthStatus;
+	checks: HealthCheckReport[];
+	timestamp: string;
+}
+
+/**
+ * Orchestrates execution of all discovered attestors and computes the
+ * aggregate status.
+ *
+ * Attestors are run in parallel via `Promise.all`. Each invocation is
+ * isolated by the runner so a failure or timeout in one attestor
+ * cannot affect the others. Cache lookups happen before invocation;
+ * cache writes happen after.
+ */
+@Injectable()
+export class HealthzService {
+	private readonly cache: AttestorCache;
+
+	public constructor(
+		private readonly explorer: AttestorExplorer,
+		private readonly runner: AttestorRunner,
+	) {
+		this.cache = new AttestorCache();
+	}
+
+	public async runAll(): Promise<AggregateReport> {
+		const attestors = this.explorer.getAll();
+
+		const checks = await Promise.all(
+			attestors.map((attestor) => this.runOne(attestor)),
+		);
+
+		return {
+			status: this.deriveStatus(checks),
+			checks,
+			timestamp: new Date().toISOString(),
+		};
+	}
+
+	private async runOne(
+		attestor: RegisteredAttestor,
+	): Promise<HealthCheckReport> {
+		const cached = this.cache.get(attestor.options.name);
+
+		if (cached !== undefined) {
+			return this.toReport(attestor, {
+				outcome: cached.outcome,
+				durationMs: cached.durationMs,
+				cached: true,
+			});
+		}
+
+		const { outcome, durationMs } = await this.runner.execute(attestor);
+
+		const minIntervalMs = attestor.options.minIntervalMs;
+
+		if (minIntervalMs !== undefined) {
+			this.cache.set(
+				attestor.options.name,
+				{ outcome, durationMs },
+				minIntervalMs,
+			);
+		}
+
+		return this.toReport(attestor, { outcome, durationMs, cached: false });
+	}
+
+	private toReport(
+		attestor: RegisteredAttestor,
+		result: {
+			outcome: HealthCheckOutcome;
+			durationMs: number;
+			cached: boolean;
+		},
+	): HealthCheckReport {
+		const report: HealthCheckReport = {
+			name: attestor.options.name,
+			status: result.outcome.status,
+			critical: attestor.options.critical ?? true,
+			durationMs: result.durationMs,
+			cached: result.cached,
+		};
+
+		if (result.outcome.details !== undefined) {
+			report.details = result.outcome.details;
+		}
+
+		return report;
+	}
+
+	private deriveStatus(checks: readonly HealthCheckReport[]): HealthStatus {
+		let degraded = false;
+
+		for (const check of checks) {
+			if (check.status === "down") {
+				if (check.critical) {
+					return "down";
+				}
+
+				degraded = true;
+			}
+		}
+
+		return degraded ? "degraded" : "ok";
+	}
+}

--- a/packages/healthz/src/index.ts
+++ b/packages/healthz/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @abinnovision/nestjs-healthz
+ *
+ * Self-mounting health check module for NestJS with cross-module
+ * attestor discovery, per-attestor caching, and Kubernetes-style
+ * `/livez` and `/readyz` endpoints.
+ */
+
+export * from "./health-attestor";
+export {
+	HEALTHZ_MODULE_CONFIG_TOKEN,
+	type HealthzModuleConfig,
+} from "./healthz.module-config";
+export { HealthzModule } from "./healthz.module";
+export type { HealthStatus } from "./interfaces/health-status";

--- a/packages/healthz/src/interfaces/health-status.ts
+++ b/packages/healthz/src/interfaces/health-status.ts
@@ -1,0 +1,11 @@
+/**
+ * Aggregate health status used by both per-attestor outcomes and the
+ * overall `/readyz` response.
+ *
+ * - `ok` — fully operational.
+ * - `degraded` — one or more non-critical checks failed; the
+ *   application should still serve traffic.
+ * - `down` — at least one critical check failed; the application
+ *   should not serve traffic.
+ */
+export type HealthStatus = "ok" | "degraded" | "down";

--- a/packages/healthz/src/metadata/keys.ts
+++ b/packages/healthz/src/metadata/keys.ts
@@ -1,0 +1,6 @@
+/**
+ * Reflect metadata key used by `@HealthAttestor()` to attach its
+ * options to the decorated class. The explorer reads this key when
+ * walking the DI container at application bootstrap.
+ */
+export const METADATA_KEY_HEALTH_ATTESTOR = Symbol("healthz:attestor");

--- a/packages/healthz/src/runner/attestor-runner.service.spec.ts
+++ b/packages/healthz/src/runner/attestor-runner.service.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { AttestorRunner } from "./attestor-runner.service";
+
+import type { HealthAttestor, HealthCheckOutcome } from "../health-attestor";
+import type { RegisteredAttestor } from "./attestor-runner.service";
+
+const buildRegistered = (
+	check: HealthAttestor["check"],
+	overrides: Partial<RegisteredAttestor["options"]> = {},
+): RegisteredAttestor => ({
+	options: { name: "subject", ...overrides },
+	instance: { check },
+});
+
+describe("runner/attestor-runner.service.ts", () => {
+	describe("attestorRunner.execute()", () => {
+		it("returns the attestor outcome on success", async () => {
+			const runner = new AttestorRunner();
+			const outcome: HealthCheckOutcome = { status: "ok" };
+
+			const result = await runner.execute(buildRegistered(() => outcome));
+
+			expect(result.outcome).toEqual(outcome);
+			expect(result.durationMs).toBeGreaterThanOrEqual(0);
+		});
+
+		it("awaits async check() implementations", async () => {
+			const runner = new AttestorRunner();
+			const outcome: HealthCheckOutcome = { status: "ok" };
+
+			const result = await runner.execute(
+				buildRegistered(() => Promise.resolve(outcome)),
+			);
+
+			expect(result.outcome).toEqual(outcome);
+		});
+
+		it("converts a thrown error into a `down` outcome", async () => {
+			const runner = new AttestorRunner();
+
+			const result = await runner.execute(
+				buildRegistered(() => {
+					throw new Error("connection refused");
+				}),
+			);
+
+			expect(result.outcome).toEqual({ status: "down" });
+		});
+
+		it("converts a rejected promise into a `down` outcome", async () => {
+			const runner = new AttestorRunner();
+
+			const result = await runner.execute(
+				buildRegistered(() => Promise.reject(new Error("nope"))),
+			);
+
+			expect(result.outcome).toEqual({ status: "down" });
+		});
+
+		it("times out a slow check() and reports `down`", async () => {
+			const runner = new AttestorRunner();
+
+			const slow = (): Promise<HealthCheckOutcome> =>
+				new Promise((resolve) => {
+					setTimeout(() => {
+						resolve({ status: "ok" });
+					}, 200);
+				});
+
+			const result = await runner.execute(
+				buildRegistered(slow, { timeoutMs: 20 }),
+			);
+
+			expect(result.outcome).toEqual({ status: "down" });
+		});
+
+		it("handles non-Error throwables by isolating them as `down`", async () => {
+			const runner = new AttestorRunner();
+
+			const result = await runner.execute(
+				buildRegistered(() => {
+					// eslint-disable-next-line @typescript-eslint/only-throw-error
+					throw "string-error";
+				}),
+			);
+
+			expect(result.outcome).toEqual({ status: "down" });
+		});
+
+		it("does not surface the underlying error message on the outcome", async () => {
+			const runner = new AttestorRunner();
+
+			const result = await runner.execute(
+				buildRegistered(() => {
+					throw new Error("internal: db password rotated");
+				}),
+			);
+
+			expect(result.outcome).toEqual({ status: "down" });
+			expect(JSON.stringify(result.outcome)).not.toContain("db password");
+		});
+	});
+});

--- a/packages/healthz/src/runner/attestor-runner.service.ts
+++ b/packages/healthz/src/runner/attestor-runner.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import type {
+	HealthAttestor,
+	HealthAttestorOptions,
+	HealthCheckOutcome,
+} from "../health-attestor";
+
+const DEFAULT_TIMEOUT_MS = 2000;
+
+/**
+ * Executes a single attestor with timeout and exception isolation.
+ *
+ * No exception escapes `execute()` — anything thrown by the attestor's
+ * `check()` is converted to a `{ status: "down" }` outcome. Timeouts
+ * produce the same shape. The underlying error message is logged so
+ * operators can diagnose a failing check, but it is intentionally not
+ * placed on the outcome so that probe responses never leak internal
+ * error text to callers.
+ */
+@Injectable()
+export class AttestorRunner {
+	private static readonly LOGGER = new Logger(AttestorRunner.name);
+
+	public async execute(attestor: RegisteredAttestor): Promise<ExecutionResult> {
+		const timeoutMs = attestor.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+		const start = Date.now();
+
+		try {
+			const outcome = await this.withTimeout(
+				Promise.resolve(attestor.instance.check()),
+				timeoutMs,
+			);
+
+			return { outcome, durationMs: Date.now() - start };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+
+			AttestorRunner.LOGGER.warn(
+				`Attestor '${attestor.options.name}' reported down: ${message}`,
+			);
+
+			return {
+				outcome: { status: "down" },
+				durationMs: Date.now() - start,
+			};
+		}
+	}
+
+	private async withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+		let timer: ReturnType<typeof setTimeout> | undefined;
+
+		const timeout = new Promise<never>((_, reject) => {
+			timer = setTimeout(() => {
+				reject(new Error("timeout"));
+			}, ms);
+		});
+
+		try {
+			return await Promise.race([promise, timeout]);
+		} finally {
+			if (timer !== undefined) {
+				clearTimeout(timer);
+			}
+		}
+	}
+}
+
+/**
+ * A bound pair of attestor metadata and its DI-instantiated provider,
+ * produced by the explorer and consumed by the runner.
+ */
+export interface RegisteredAttestor {
+	options: HealthAttestorOptions;
+	instance: HealthAttestor;
+}
+
+/**
+ * The result of executing a single attestor — its reported outcome
+ * and the wall-clock duration of the call.
+ */
+export interface ExecutionResult {
+	outcome: HealthCheckOutcome;
+	durationMs: number;
+}

--- a/packages/healthz/tsconfig.build.json
+++ b/packages/healthz/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": ["../../tsconfig.base.json"],
+	"compilerOptions": {
+		"outDir": "./dist",
+		"noEmit": false
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["src/**/*.spec.ts"]
+}

--- a/packages/healthz/tsconfig.json
+++ b/packages/healthz/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": ["../../tsconfig.base.json"]
+}

--- a/packages/healthz/vitest.config.mts
+++ b/packages/healthz/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+	test: {
+		name: "@abinnovision/nestjs-healthz#unit",
+		include: ["src/**/*.spec.ts", "src/**/*.spec.mts"],
+		environment: "node",
+	},
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,7 @@
 			"bump-minor-pre-major": false,
 			"bump-patch-for-minor-pre-major": false
 		},
+		"packages/healthz": {},
 		"packages/toolkit": {},
 		"apps/docs": {}
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,6 +111,27 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@abinnovision/nestjs-healthz@workspace:packages/healthz":
+  version: 0.0.0-use.local
+  resolution: "@abinnovision/nestjs-healthz@workspace:packages/healthz"
+  dependencies:
+    "@abinnovision/eslint-config-base": "npm:^3.4.1"
+    "@abinnovision/prettier-config": "npm:^2.2.0"
+    "@nestjs/common": "npm:^11.0.0"
+    "@nestjs/core": "npm:^11.0.0"
+    "@swc/core": "npm:^1.11.5"
+    eslint: "npm:^10.3.0"
+    prettier: "npm:^3.8.3"
+    reflect-metadata: "npm:^0.2.2"
+    rxjs: "npm:^7.8.1"
+    typescript: "npm:^5.8.2"
+    vitest: "npm:^4.0.15"
+  peerDependencies:
+    "@nestjs/common": ^11.0.0
+    "@nestjs/core": ^11.0.0
+  languageName: unknown
+  linkType: soft
+
 "@abinnovision/nestjs-toolkit@workspace:packages/toolkit":
   version: 0.0.0-use.local
   resolution: "@abinnovision/nestjs-toolkit@workspace:packages/toolkit"


### PR DESCRIPTION
## Summary

- Introduces `@abinnovision/nestjs-healthz` — a drop-in NestJS module that mounts Kubernetes-style `/livez`, `/readyz`, and `/healthz` endpoints and discovers `@HealthAttestor()`-decorated providers across the application graph via NestJS `DiscoveryService`.
- Attestors live in their source modules with full DI access; `HealthzModule` aggregates results with three-state status (`ok` / `degraded` / `down` with a per-attestor `critical` flag), per-attestor execution rate-limiting (`minIntervalMs`), and timeouts.
- Errors thrown by `check()` are logged but never surfaced on the response payload, and `details` is restricted to `Record<string, string>` to keep the probe response predictable and avoid leaking internals.
- Adds the package to the root README package table; ships with 97.97% statement coverage across 27 unit tests.

## Test plan

- [ ] CI runs `yarn build`, `yarn check`, and `yarn test-unit` against the new package
- [ ] Wire `HealthzModule.forRoot({})` into a downstream service and confirm `curl /readyz` returns the aggregate report
- [ ] Decorate a provider with `@HealthAttestor({ name, critical: false })`, confirm the response is `degraded` + HTTP 200 when its `check()` fails
- [ ] Confirm `minIntervalMs` prevents the underlying `check()` from running on every probe