### PR TITLE
fix(hatchet): tolerate startup with no forFeature registrations

### DIFF
--- a/packages/hatchet/src/explorer/worker-management.service.spec.ts
+++ b/packages/hatchet/src/explorer/worker-management.service.spec.ts
@@ -19,6 +19,7 @@ import type { ModuleRef } from "@nestjs/core";
 const createService = (opts: {
 	config: HatchetModuleConfig;
 	registrations?: HatchetFeatureRegistration[];
+	registrationsLookupShouldThrow?: boolean;
 	serverWorkflows?: Array<{ name: string }>;
 	serverWorkflowPages?: Array<Array<{ name: string }>>;
 	listShouldReject?: boolean;
@@ -29,8 +30,19 @@ const createService = (opts: {
 
 	const registrations = opts.registrations ?? [];
 
-	// discoverFeatureRegistrations calls moduleRef.get once per invocation.
-	mockModuleRef.get.mockReturnValue(registrations);
+	/*
+	 * discoverFeatureRegistrations calls moduleRef.get once per invocation.
+	 * When `registrationsLookupShouldThrow` is set we mirror Nest's real
+	 * behaviour of throwing `UnknownElementException` for absent providers,
+	 * since the default mock would otherwise hide the bug from issue #105.
+	 */
+	if (opts.registrationsLookupShouldThrow) {
+		mockModuleRef.get.mockImplementation(() => {
+			throw new Error("UnknownElementException");
+		});
+	} else {
+		mockModuleRef.get.mockReturnValue(registrations);
+	}
 
 	// Mock workflows.list
 	if (opts.listShouldReject) {
@@ -83,6 +95,38 @@ describe("worker-management.service.ts", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+	});
+
+	describe("initWorker (onApplicationBootstrap)", () => {
+		it("does not throw when no forFeature() registrations exist", async () => {
+			/*
+			 * Reproduces issue #105: with `forRoot()` only and no `forFeature()`
+			 * calls, Nest's ModuleRef throws `UnknownElementException` when asked
+			 * for the registration token. The service must swallow that and skip
+			 * worker initialization instead of failing application bootstrap.
+			 */
+			const { service, mockClient } = createService({
+				config: {
+					...workerConfig,
+					enableOrphanDetection: false,
+				},
+				registrationsLookupShouldThrow: true,
+			});
+
+			await expect(service.onApplicationBootstrap()).resolves.toBeUndefined();
+
+			expect(mockClient.worker).not.toHaveBeenCalled();
+		});
+
+		it("skips worker initialization when worker config is undefined", async () => {
+			const { service, mockClient } = createService({
+				config: noWorkerConfig,
+			});
+
+			await service.onApplicationBootstrap();
+
+			expect(mockClient.worker).not.toHaveBeenCalled();
+		});
 	});
 
 	describe("detectOrphanWorkflows", () => {

--- a/packages/hatchet/src/explorer/worker-management.service.ts
+++ b/packages/hatchet/src/explorer/worker-management.service.ts
@@ -92,12 +92,21 @@ export class WorkerManagementService implements OnApplicationBootstrap {
 
 	/**
 	 * Discovers all feature registrations from forFeature() calls.
+	 *
+	 * Returns an empty array when no `HatchetModule.forFeature()` has been
+	 * registered anywhere. Nest's `ModuleRef.get(..., { each: true })` throws
+	 * `UnknownElementException` when zero providers exist for the token, even
+	 * with `strict: false`, so we catch that case and treat it as "no features".
 	 */
 	private discoverFeatureRegistrations(): HatchetFeatureRegistration[] {
-		return this.moduleRef.get(HatchetFeatureRegistration, {
-			strict: false,
-			each: true,
-		});
+		try {
+			return this.moduleRef.get(HatchetFeatureRegistration, {
+				strict: false,
+				each: true,
+			});
+		} catch {
+			return [];
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Closes #105.

`WorkerManagementService.discoverFeatureRegistrations` called `moduleRef.get(HatchetFeatureRegistration, { strict: false, each: true })`, which throws `UnknownElementException` when zero providers exist for the token — `strict: false` only widens the search scope, it doesn't silence missing-provider errors. As a result, importing `HatchetModule.forRoot(...)` without any `HatchetModule.forFeature(...)` calls aborted application bootstrap. The lookup is now wrapped so an empty result is treated as "no features" and worker initialization is skipped via the existing `refCount === 0` early return.

## Test plan

- [x] `yarn workspace @abinnovision/nestjs-hatchet test-unit` (new spec reproduces #105 by making `moduleRef.get` throw, plus existing 196 tests pass)
- [x] `yarn workspace @abinnovision/nestjs-hatchet build`
- [x] `yarn workspace @abinnovision/nestjs-hatchet lint:check`