### PR TITLE
feat(healthz): narrow probe response shape

### DIFF
--- a/packages/healthz/README.md
+++ b/packages/healthz/README.md
@@ -19,12 +19,12 @@ yarn add @abinnovision/nestjs-healthz
 import { HealthzModule } from "@abinnovision/nestjs-healthz";
 
 @Module({
-  imports: [DatabaseModule, HealthzModule.forRoot({})],
+  imports: [DatabaseModule, HealthzModule.forRoot()],
 })
 export class AppModule {}
 ```
 
-`HealthzModule.forRoot({})` is global — every module that loads into
+`HealthzModule.forRoot()` is global — every module that loads into
 the app graph is scanned for attestors.
 
 ### 2. Declare an attestor inside the module that owns the dependency
@@ -133,8 +133,6 @@ text to whoever curls `/readyz`.
 
 ## Response shape
 
-Default response (`detail: "full"`):
-
 ```json
 {
   "status": "ok",
@@ -142,44 +140,31 @@ Default response (`detail: "full"`):
     {
       "name": "database",
       "status": "ok",
-      "critical": true,
-      "durationMs": 12,
-      "cached": false
+      "durationMs": 12
     },
     {
       "name": "redis",
       "status": "down",
-      "critical": false,
-      "durationMs": 2003,
-      "cached": false
+      "durationMs": 2003
     }
   ],
   "timestamp": "2026-05-13T12:34:56.000Z"
 }
 ```
 
-The detail level is configurable via `HealthzModule.forRoot()`:
-
-```typescript
-HealthzModule.forRoot({ detail: "summary" });
-```
-
-| `detail`    | Body                                                     |
-| ----------- | -------------------------------------------------------- |
-| `"full"`    | Aggregate status + per-attestor breakdown (default).     |
-| `"summary"` | `{ status, timestamp }` only.                            |
-| `"none"`    | Empty body — clients rely on the HTTP status code alone. |
-
-The HTTP status code is identical across detail modes.
+The HTTP status code is `503` when the aggregate status is `"down"`
+and `200` otherwise.
 
 ## API
 
-### `HealthzModule.forRoot(config)`
+### `HealthzModule.forRoot()`
 
-Registers the module globally and mounts the three endpoints.
+Registers the module globally and mounts the three endpoints. Takes
+no arguments today; reserved as the canonical entry point for any
+future module configuration.
 
 ```typescript
-HealthzModule.forRoot({ detail: "full" });
+HealthzModule.forRoot();
 ```
 
 ### `@HealthAttestor(options)`
@@ -218,11 +203,11 @@ interface HealthCheckOutcome {
 }
 ```
 
-`details` is surfaced in `detail: "full"` responses — useful for
-small, safe-to-publish diagnostics (e.g. `{ "lag_seconds": "12" }`).
-Values are restricted to strings so the response stays predictable
-and no caller can accidentally publish unbounded objects or sensitive
-fields.
+`details` is surfaced under `checks[].details` in the response —
+useful for small, safe-to-publish diagnostics (e.g.
+`{ "lag_seconds": "12" }`). Values are restricted to strings so the
+response stays predictable and no caller can accidentally publish
+unbounded objects or sensitive fields.
 
 ## License
 

--- a/packages/healthz/src/health-attestor.ts
+++ b/packages/healthz/src/health-attestor.ts
@@ -23,8 +23,8 @@ export interface HealthCheckOutcome {
 	status: Exclude<HealthStatus, "degraded">;
 
 	/**
-	 * Optional structured details surfaced in the response payload when
-	 * the configured detail level includes per-attestor information.
+	 * Optional structured details surfaced in the response payload
+	 * under `checks[].details`.
 	 *
 	 * Values are restricted to strings to keep the response payload
 	 * predictable and avoid accidental serialisation of unbounded
@@ -104,9 +104,7 @@ export interface HealthAttestorOptions {
 export interface HealthCheckReport {
 	name: string;
 	status: HealthStatus;
-	critical: boolean;
 	durationMs: number;
-	cached: boolean;
 	details?: Record<string, string>;
 }
 

--- a/packages/healthz/src/healthz.controller.ts
+++ b/packages/healthz/src/healthz.controller.ts
@@ -1,9 +1,6 @@
-import { Controller, Get, HttpStatus, Inject, Res } from "@nestjs/common";
+import { Controller, Get, HttpStatus, Res } from "@nestjs/common";
 
-import { HEALTHZ_MODULE_CONFIG_TOKEN } from "./healthz.module-config";
 import { HealthzService } from "./healthz.service";
-
-import type { HealthzModuleConfig } from "./healthz.module-config";
 
 /**
  * Minimal structural shape covering both Express' `Response` and
@@ -27,11 +24,7 @@ interface ResponseLike {
  */
 @Controller()
 export class HealthzController {
-	public constructor(
-		private readonly service: HealthzService,
-		@Inject(HEALTHZ_MODULE_CONFIG_TOKEN)
-		private readonly config: HealthzModuleConfig,
-	) {}
+	public constructor(private readonly service: HealthzService) {}
 
 	@Get("livez")
 	public livez(): { status: "ok"; timestamp: string } {
@@ -58,16 +51,6 @@ export class HealthzController {
 		res.status(
 			report.status === "down" ? HttpStatus.SERVICE_UNAVAILABLE : HttpStatus.OK,
 		);
-
-		const detail = this.config.detail ?? "full";
-
-		if (detail === "none") {
-			return undefined;
-		}
-
-		if (detail === "summary") {
-			return { status: report.status, timestamp: report.timestamp };
-		}
 
 		return report;
 	}

--- a/packages/healthz/src/healthz.module-config.ts
+++ b/packages/healthz/src/healthz.module-config.ts
@@ -1,30 +1,9 @@
 /**
  * Options accepted by `HealthzModule.forRoot()`.
  *
- * All fields are optional; calling `HealthzModule.forRoot({})` is
- * equivalent to relying on every default.
+ * Reserved as an extension point. No options are recognised today —
+ * calling `HealthzModule.forRoot()` with no arguments is the only
+ * supported form.
  */
-export interface HealthzModuleConfig {
-	/**
-	 * How much information to include in the response body.
-	 *
-	 * - `"full"` (default): full breakdown including per-attestor
-	 *   status, duration, error message, and cache state.
-	 * - `"summary"`: only the aggregate `{ status, timestamp }`.
-	 * - `"none"`: empty body — only the HTTP status code carries
-	 *   information.
-	 *
-	 * The HTTP status code is the same in all three modes: 503 when the
-	 * aggregate status is `down`, 200 otherwise.
-	 *
-	 * @default "full"
-	 */
-	detail?: "full" | "summary" | "none";
-}
-
-/**
- * Injection token under which the resolved `HealthzModuleConfig` is
- * provided. Exported for advanced use; most consumers do not need to
- * reference it directly.
- */
-export const HEALTHZ_MODULE_CONFIG_TOKEN = Symbol("healthz:module:config");
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface HealthzModuleConfig {}

--- a/packages/healthz/src/healthz.module.ts
+++ b/packages/healthz/src/healthz.module.ts
@@ -3,16 +3,14 @@ import { DiscoveryModule } from "@nestjs/core";
 
 import { AttestorExplorer } from "./explorer/attestor-explorer.service";
 import { HealthzController } from "./healthz.controller";
-import { HEALTHZ_MODULE_CONFIG_TOKEN } from "./healthz.module-config";
 import { HealthzService } from "./healthz.service";
 import { AttestorRunner } from "./runner/attestor-runner.service";
 
-import type { HealthzModuleConfig } from "./healthz.module-config";
 import type { DynamicModule } from "@nestjs/common";
 
 /**
  * The healthz module — import once at the application root via
- * `HealthzModule.forRoot({})` to mount the `/livez`, `/readyz`, and
+ * `HealthzModule.forRoot()` to mount the `/livez`, `/readyz`, and
  * `/healthz` endpoints and enable discovery of `@HealthAttestor()`
  * providers across the application graph.
  *
@@ -25,7 +23,7 @@ import type { DynamicModule } from "@nestjs/common";
  * @Module({
  *   imports: [
  *     DatabaseModule,
- *     HealthzModule.forRoot({}),
+ *     HealthzModule.forRoot(),
  *   ],
  * })
  * export class AppModule {}
@@ -39,21 +37,15 @@ import type { DynamicModule } from "@nestjs/common";
 })
 export class HealthzModule {
 	/**
-	 * Registers the healthz module globally and binds its configuration.
+	 * Registers the healthz module globally.
 	 *
-	 * All fields of `config` are optional — `forRoot({})` is the
-	 * minimal call to accept every default.
+	 * Takes no arguments today; reserved as the canonical entry point
+	 * for any future module configuration.
 	 */
-	public static forRoot(config: HealthzModuleConfig): DynamicModule {
+	public static forRoot(): DynamicModule {
 		return {
 			module: HealthzModule,
 			global: true,
-			providers: [
-				{
-					provide: HEALTHZ_MODULE_CONFIG_TOKEN,
-					useValue: config,
-				},
-			],
 		};
 	}
 }

--- a/packages/healthz/src/healthz.service.spec.ts
+++ b/packages/healthz/src/healthz.service.spec.ts
@@ -117,7 +117,6 @@ describe("healthz.service.ts", () => {
 			const report = await service.runAll();
 
 			expect(report.status).toBe("down");
-			expect(report.checks[0]?.critical).toBe(true);
 		});
 
 		it("rate-limits execution when minIntervalMs is set and reuses the previous outcome", async () => {
@@ -139,12 +138,10 @@ describe("healthz.service.ts", () => {
 
 			const service = new HealthzService(stubExplorer(attestors), runner);
 
-			const first = await service.runAll();
-			const second = await service.runAll();
+			await service.runAll();
+			await service.runAll();
 
 			expect(executions).toBe(1);
-			expect(first.checks[0]?.cached).toBe(false);
-			expect(second.checks[0]?.cached).toBe(true);
 		});
 
 		it("re-runs uncached attestors on every call", async () => {

--- a/packages/healthz/src/healthz.service.ts
+++ b/packages/healthz/src/healthz.service.ts
@@ -18,6 +18,18 @@ export interface AggregateReport {
 }
 
 /**
+ * Internal pairing of an attestor with the result of its most recent
+ * execution. The `critical` flag is read off the attestor's options
+ * when deriving the aggregate status, so it does not need to live on
+ * the public report.
+ */
+interface AttestorRun {
+	attestor: RegisteredAttestor;
+	outcome: HealthCheckOutcome;
+	durationMs: number;
+}
+
+/**
  * Orchestrates execution of all discovered attestors and computes the
  * aggregate status.
  *
@@ -40,28 +52,26 @@ export class HealthzService {
 	public async runAll(): Promise<AggregateReport> {
 		const attestors = this.explorer.getAll();
 
-		const checks = await Promise.all(
+		const runs = await Promise.all(
 			attestors.map((attestor) => this.runOne(attestor)),
 		);
 
 		return {
-			status: this.deriveStatus(checks),
-			checks,
+			status: this.deriveStatus(runs),
+			checks: runs.map((run) => this.toReport(run)),
 			timestamp: new Date().toISOString(),
 		};
 	}
 
-	private async runOne(
-		attestor: RegisteredAttestor,
-	): Promise<HealthCheckReport> {
+	private async runOne(attestor: RegisteredAttestor): Promise<AttestorRun> {
 		const cached = this.cache.get(attestor.options.name);
 
 		if (cached !== undefined) {
-			return this.toReport(attestor, {
+			return {
+				attestor,
 				outcome: cached.outcome,
 				durationMs: cached.durationMs,
-				cached: true,
-			});
+			};
 		}
 
 		const { outcome, durationMs } = await this.runner.execute(attestor);
@@ -76,38 +86,31 @@ export class HealthzService {
 			);
 		}
 
-		return this.toReport(attestor, { outcome, durationMs, cached: false });
+		return { attestor, outcome, durationMs };
 	}
 
-	private toReport(
-		attestor: RegisteredAttestor,
-		result: {
-			outcome: HealthCheckOutcome;
-			durationMs: number;
-			cached: boolean;
-		},
-	): HealthCheckReport {
+	private toReport(run: AttestorRun): HealthCheckReport {
 		const report: HealthCheckReport = {
-			name: attestor.options.name,
-			status: result.outcome.status,
-			critical: attestor.options.critical ?? true,
-			durationMs: result.durationMs,
-			cached: result.cached,
+			name: run.attestor.options.name,
+			status: run.outcome.status,
+			durationMs: run.durationMs,
 		};
 
-		if (result.outcome.details !== undefined) {
-			report.details = result.outcome.details;
+		if (run.outcome.details !== undefined) {
+			report.details = run.outcome.details;
 		}
 
 		return report;
 	}
 
-	private deriveStatus(checks: readonly HealthCheckReport[]): HealthStatus {
+	private deriveStatus(runs: readonly AttestorRun[]): HealthStatus {
 		let degraded = false;
 
-		for (const check of checks) {
-			if (check.status === "down") {
-				if (check.critical) {
+		for (const run of runs) {
+			if (run.outcome.status === "down") {
+				const critical = run.attestor.options.critical ?? true;
+
+				if (critical) {
 					return "down";
 				}
 

--- a/packages/healthz/src/index.ts
+++ b/packages/healthz/src/index.ts
@@ -7,9 +7,6 @@
  */
 
 export * from "./health-attestor";
-export {
-	HEALTHZ_MODULE_CONFIG_TOKEN,
-	type HealthzModuleConfig,
-} from "./healthz.module-config";
+export { type HealthzModuleConfig } from "./healthz.module-config";
 export { HealthzModule } from "./healthz.module";
 export type { HealthStatus } from "./interfaces/health-status";


### PR DESCRIPTION
## Summary
- Drops `critical` and `cached` from per-attestor entries in the `/readyz` / `/healthz` payload — they leaked internal mechanics (cache hits, aggregation rules) without value to probe consumers.
- Removes the `detail: "full" | "summary" | "none"` module option and the now-unused `HEALTHZ_MODULE_CONFIG_TOKEN`; the controller always returns the aggregate status, per-attestor breakdown, and timestamp.
- `HealthzModule.forRoot()` is now zero-argument; `HealthzModuleConfig` is kept as an empty extension-point interface.
- `critical` and `minIntervalMs` remain meaningful **inputs** on `@HealthAttestor()` — only their reflection in the response is removed.

## Test plan
- [x] `yarn build` (package + workspace)
- [x] `yarn test-unit` — 27/27 specs pass
- [ ] Manual curl of `/healthz` in a consuming app to confirm absence of `critical` / `cached` keys