### PR TITLE
feat(toolkit): add toUUID() validating parse helper

### DIFF
--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -12,7 +12,7 @@ yarn add @abinnovision/nestjs-toolkit
 
 The package exposes two surfaces:
 
-- **Direct, data-first helpers** — `slugify(data, opts?)`, `sanitizeString(data, opts?)`, `generateUUID(...)`, `isUUID(...)`, `isNullishOrEmptyString(...)`, plus UUID namespace constants and types.
+- **Direct, data-first helpers** — `slugify(data, opts?)`, `sanitizeString(data, opts?)`, `generateUUID(...)`, `isUUID(...)`, `toUUID(...)`, `isNullishOrEmptyString(...)`, plus UUID namespace constants and types.
 - **`R` namespace** — every function from `remeda` plus data-last / pipe-friendly variants of the helpers above: `R.slugify(opts?)`, `R.sanitizeString(opts?)`, `R.isUUID`, `R.isNullishOrEmptyString`.
 
 ```typescript

--- a/packages/toolkit/src/uuid/index.ts
+++ b/packages/toolkit/src/uuid/index.ts
@@ -1,4 +1,5 @@
 export * from "./is-uuid";
 export * from "./generate-uuid";
+export * from "./to-uuid";
 export * from "./uuid-namespaces";
 export * from "./uuid.types";

--- a/packages/toolkit/src/uuid/to-uuid.spec.ts
+++ b/packages/toolkit/src/uuid/to-uuid.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { toUUID } from "./to-uuid";
+
+describe("uuid/to-uuid.ts", () => {
+	describe("#toUUID()", () => {
+		it("returns the value branded as UUID for a valid v4 string", () => {
+			const raw = "550e8400-e29b-41d4-a716-446655440000";
+
+			expect(toUUID(raw)).toBe(raw);
+		});
+
+		it("accepts other valid UUID versions", () => {
+			const raw = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+			expect(toUUID(raw)).toBe(raw);
+		});
+
+		it("throws TypeError for an invalid UUID string", () => {
+			expect(() => toUUID("not-a-uuid")).toThrow(TypeError);
+		});
+
+		it("throws TypeError for a string without hyphens", () => {
+			expect(() => toUUID("550e8400e29b41d4a716446655440000")).toThrow(
+				TypeError,
+			);
+		});
+
+		it("throws TypeError for an empty string", () => {
+			expect(() => toUUID("")).toThrow(TypeError);
+		});
+
+		it("includes the invalid value in the error message", () => {
+			expect(() => toUUID("nope")).toThrow(/nope/);
+		});
+	});
+});

--- a/packages/toolkit/src/uuid/to-uuid.ts
+++ b/packages/toolkit/src/uuid/to-uuid.ts
@@ -1,0 +1,30 @@
+import { validate } from "uuid";
+
+import type { UUID } from "./uuid.types";
+
+/**
+ * Parse a string into a validated {@link UUID}.
+ *
+ * Use this when you have a raw string that you want to treat as a `UUID`
+ * — module-scope constants, values coming out of config, or any place
+ * where an `as UUID` cast would otherwise be tempting. The format is
+ * validated at runtime; an invalid input throws.
+ *
+ * For boolean checks or in-place narrowing, use `isUUID` instead.
+ *
+ * @example
+ * ```typescript
+ * const NS = toUUID("f47ac10b-58cc-4372-a567-0e02b2c3d479");
+ * ```
+ *
+ * @param value - The string to parse
+ * @returns The same string, branded as {@link UUID}
+ * @throws TypeError if `value` is not a valid UUID string
+ */
+export function toUUID(value: string): UUID {
+	if (!validate(value)) {
+		throw new TypeError(`Invalid UUID: ${value}`);
+	}
+
+	return value as UUID;
+}

--- a/packages/toolkit/src/uuid/uuid-namespaces.ts
+++ b/packages/toolkit/src/uuid/uuid-namespaces.ts
@@ -1,33 +1,35 @@
 import { v5 } from "uuid";
 
-import type { UUID } from "./uuid.types";
+import { toUUID } from "./to-uuid";
 
 /**
  * The DNS namespace UUID for use with v5 deterministic generation.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc4122#appendix-C RFC 4122 Appendix C}
  */
-export const UUID_NAMESPACE_DNS = v5.DNS as UUID;
+export const UUID_NAMESPACE_DNS = toUUID(v5.DNS);
 
 /**
  * The URL namespace UUID for use with v5 deterministic generation.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc4122#appendix-C RFC 4122 Appendix C}
  */
-export const UUID_NAMESPACE_URL = v5.URL as UUID;
+export const UUID_NAMESPACE_URL = toUUID(v5.URL);
 
 /**
  * The ISO OID namespace UUID for use with v5 deterministic generation.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc4122#appendix-C RFC 4122 Appendix C}
  */
-export const UUID_NAMESPACE_OID =
-	"6ba7b812-9dad-11d1-80b4-00c04fd430c8" as UUID;
+export const UUID_NAMESPACE_OID = toUUID(
+	"6ba7b812-9dad-11d1-80b4-00c04fd430c8",
+);
 
 /**
  * The X.500 DN namespace UUID for use with v5 deterministic generation.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc4122#appendix-C RFC 4122 Appendix C}
  */
-export const UUID_NAMESPACE_X500 =
-	"6ba7b814-9dad-11d1-80b4-00c04fd430c8" as UUID;
+export const UUID_NAMESPACE_X500 = toUUID(
+	"6ba7b814-9dad-11d1-80b4-00c04fd430c8",
+);


### PR DESCRIPTION
## Summary
- Adds `toUUID(value)` to convert raw strings into the branded `UUID` type with runtime validation (throws `TypeError` on invalid input). Use it instead of `as UUID` for module-scope constants or ingress conversion.
- Replaces the four internal `as UUID` casts in `uuid-namespaces.ts` with `toUUID(...)`, so the toolkit no longer leaks the foot-gun it warns users about.
- Updates the toolkit README to list the new helper.

## Test plan
- [x] `yarn workspace @abinnovision/nestjs-toolkit test-unit` — 72/72 pass, 100% coverage
- [x] `yarn workspace @abinnovision/nestjs-toolkit build` — clean