### PR TITLE
feat(toolkit): add assertNever and deepEqual utilities

### DIFF
--- a/packages/toolkit/src/assert/assert-never.spec.ts
+++ b/packages/toolkit/src/assert/assert-never.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { assertNever } from "./assert-never";
+
+describe("assert/assert-never.ts", () => {
+	describe("#assertNever()", () => {
+		it("throws when reached at runtime", () => {
+			expect(() => assertNever("unexpected" as never)).toThrow(Error);
+		});
+
+		it("includes the offending value in the error message", () => {
+			expect(() => assertNever("foo" as never)).toThrow("Unhandled case: foo");
+		});
+
+		it("handles numeric values in the message", () => {
+			expect(() => assertNever(42 as never)).toThrow("Unhandled case: 42");
+		});
+	});
+});

--- a/packages/toolkit/src/assert/assert-never.ts
+++ b/packages/toolkit/src/assert/assert-never.ts
@@ -1,0 +1,28 @@
+/**
+ * Exhaustive check helper for discriminated unions.
+ *
+ * Use in `default` branches of `switch` statements (or in the final `else` of
+ * a chain) to ensure every variant of a union is handled. The compiler will
+ * fail the build if a new variant is added without updating the caller, and
+ * the function throws at runtime if it is ever reached.
+ *
+ * @example
+ * ```typescript
+ * type Shape = { kind: "circle" } | { kind: "square" };
+ *
+ * function area(shape: Shape): number {
+ *   switch (shape.kind) {
+ *     case "circle": return 1;
+ *     case "square": return 2;
+ *     default: return assertNever(shape);
+ *   }
+ * }
+ * ```
+ *
+ * @param value - The value that should have been narrowed to `never`
+ * @throws Error - Always, including the offending value in the message
+ */
+export function assertNever(value: never): never {
+	// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+	throw new Error(`Unhandled case: ${value}`);
+}

--- a/packages/toolkit/src/assert/index.ts
+++ b/packages/toolkit/src/assert/index.ts
@@ -1,0 +1,1 @@
+export * from "./assert-never";

--- a/packages/toolkit/src/equality/deep-equal.spec.ts
+++ b/packages/toolkit/src/equality/deep-equal.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { deepEqual } from "./deep-equal";
+
+describe("equality/deep-equal.ts", () => {
+	describe("#deepEqual()", () => {
+		describe("primitives", () => {
+			it("returns true for equal strings", () => {
+				expect(deepEqual("foo", "foo")).toBe(true);
+			});
+
+			it("returns false for different strings", () => {
+				expect(deepEqual("foo", "bar")).toBe(false);
+			});
+
+			it("treats NaN as equal to NaN", () => {
+				expect(deepEqual(Number.NaN, Number.NaN)).toBe(true);
+			});
+
+			it("treats +0 and -0 as not equal", () => {
+				expect(deepEqual(0, -0)).toBe(false);
+			});
+
+			it("does not coerce types", () => {
+				expect(deepEqual(1, "1")).toBe(false);
+			});
+		});
+
+		describe("plain objects", () => {
+			it("returns true for structurally equal objects", () => {
+				expect(deepEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } })).toBe(
+					true,
+				);
+			});
+
+			it("returns false when an object has an extra key", () => {
+				expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+			});
+
+			it("distinguishes missing keys from explicit undefined", () => {
+				expect(deepEqual({ a: 1 }, { a: 1, b: undefined })).toBe(false);
+			});
+		});
+
+		describe("arrays", () => {
+			it("returns true for arrays with equal contents", () => {
+				expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+			});
+
+			it("returns false when order differs", () => {
+				expect(deepEqual([1, 2, 3], [3, 2, 1])).toBe(false);
+			});
+
+			it("returns false when length differs", () => {
+				expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+			});
+		});
+
+		describe("map and Set", () => {
+			it("returns true for Maps with equal entries", () => {
+				const left = new Map([
+					["a", 1],
+					["b", 2],
+				]);
+				const right = new Map([
+					["b", 2],
+					["a", 1],
+				]);
+
+				expect(deepEqual(left, right)).toBe(true);
+			});
+
+			it("returns true for Sets with equal members", () => {
+				expect(deepEqual(new Set([1, 2, 3]), new Set([3, 2, 1]))).toBe(true);
+			});
+		});
+
+		describe("date", () => {
+			it("returns true for Date values with the same time", () => {
+				expect(
+					deepEqual(new Date("2024-01-01T00:00:00Z"), new Date(1704067200000)),
+				).toBe(true);
+			});
+
+			it("returns false for Date values with different times", () => {
+				expect(deepEqual(new Date("2024-01-01"), new Date("2024-01-02"))).toBe(
+					false,
+				);
+			});
+		});
+
+		describe("different shapes", () => {
+			it("returns false when comparing an array to a plain object", () => {
+				expect(deepEqual([1, 2, 3], { 0: 1, 1: 2, 2: 3 })).toBe(false);
+			});
+		});
+	});
+});

--- a/packages/toolkit/src/equality/deep-equal.ts
+++ b/packages/toolkit/src/equality/deep-equal.ts
@@ -1,0 +1,25 @@
+import { isDeepStrictEqual } from "node:util";
+
+/**
+ * Deep structural equality check using strict comparison semantics.
+ *
+ * Delegates to {@link https://nodejs.org/api/util.html#utilisdeepstrictequalval1-val2 | `node:util#isDeepStrictEqual`}
+ * to handle plain objects, arrays, `Map`, `Set`, `Date`, `RegExp`, typed
+ * arrays, and circular references. Compares with `Object.is` semantics, so
+ * `NaN` equals `NaN` and `+0` does not equal `-0`. No type coercion is
+ * performed: a string and a number with the same textual value are not equal.
+ *
+ * @example
+ * ```typescript
+ * deepEqual({ a: 1, b: [2, 3] }, { a: 1, b: [2, 3] }); // true
+ * deepEqual(new Map([["k", 1]]), new Map([["k", 1]])); // true
+ * deepEqual({ a: 1 }, { a: 1, b: undefined });         // false
+ * ```
+ *
+ * @param a - First value to compare
+ * @param b - Second value to compare
+ * @returns True if the two values are deeply, strictly equal
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+	return isDeepStrictEqual(a, b);
+}

--- a/packages/toolkit/src/equality/index.ts
+++ b/packages/toolkit/src/equality/index.ts
@@ -1,0 +1,1 @@
+export * from "./deep-equal";

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -5,5 +5,7 @@
  */
 
 export { R } from "./remeda";
+export * from "./assert";
+export * from "./equality";
 export * from "./string";
 export * from "./uuid";


### PR DESCRIPTION
## Summary
- Adds `assertNever` (exhaustive-check helper for discriminated unions) under `src/assert/`.
- Adds `deepEqual` (deep structural equality via `node:util.isDeepStrictEqual`, zero new deps) under `src/equality/`.
- Both promoted from utility duplicates found across our backend apps (`earlyai`, `hubz`, `willow`); larger cross-app patterns (request-id middleware, Pino↔Hatchet interceptor, auth, GraphQL pagination, etc.) were intentionally not promoted as they don't fit the "tiny utility" shape.

## Test plan
- [x] `yarn workspace @abinnovision/nestjs-toolkit test-unit` — 85 tests pass, 100% coverage
- [x] `yarn workspace @abinnovision/nestjs-toolkit build`
- [x] `yarn workspace @abinnovision/nestjs-toolkit lint:check`
- [x] `yarn workspace @abinnovision/nestjs-toolkit format:check`