### PR TITLE
fix(healthz): skip non-class providers in attestor discovery

### DIFF
--- a/packages/healthz/src/explorer/attestor-explorer.service.spec.ts
+++ b/packages/healthz/src/explorer/attestor-explorer.service.spec.ts
@@ -99,6 +99,32 @@ describe("explorer/attestor-explorer.service.ts", () => {
 			expect(explorer.getAll()).toHaveLength(0);
 		});
 
+		it("skips providers whose metatype is undefined (Nest internals)", () => {
+			const explorer = new AttestorExplorer(
+				stubDiscovery([
+					{ instance: { check: () => null }, metatype: undefined },
+				]),
+			);
+
+			expect(() => {
+				explorer.onApplicationBootstrap();
+			}).not.toThrow();
+			expect(explorer.getAll()).toHaveLength(0);
+		});
+
+		it("skips providers whose metatype is a non-function token", () => {
+			const explorer = new AttestorExplorer(
+				stubDiscovery([
+					{ instance: { check: () => null }, metatype: "SOME_TOKEN" },
+				]),
+			);
+
+			expect(() => {
+				explorer.onApplicationBootstrap();
+			}).not.toThrow();
+			expect(explorer.getAll()).toHaveLength(0);
+		});
+
 		it("warns and skips a decorated class missing check()", () => {
 			@HealthAttestor({ name: "broken" })
 			class Broken {

--- a/packages/healthz/src/explorer/attestor-explorer.service.ts
+++ b/packages/healthz/src/explorer/attestor-explorer.service.ts
@@ -29,7 +29,15 @@ export class AttestorExplorer implements OnApplicationBootstrap {
 		for (const wrapper of providers) {
 			const { metatype } = wrapper;
 
-			if (metatype === null) {
+			/*
+			 * `DiscoveryService.getProviders()` returns every provider in the
+			 * application graph — including value/factory providers and Nest
+			 * internals whose `metatype` may be `null`, `undefined`, or a
+			 * non-function token. `Reflect.getMetadata` throws `TypeError`
+			 * unless the target is an object/function, so we skip anything
+			 * that isn't a class constructor before touching it.
+			 */
+			if (typeof metatype !== "function") {
 				continue;
 			}
 


### PR DESCRIPTION
## Summary

- `AttestorExplorer.onApplicationBootstrap()` walks every provider via `DiscoveryService.getProviders()` and called `Reflect.getMetadata` after only skipping `metatype === null`. Nest internals and value/factory providers can also have `undefined` or non-function token metatypes, which made `Reflect.getMetadata` throw `TypeError` and killed bootstrap (`@internal/app-backend:start:dev` crash).
- Widened the guard to `typeof metatype !== "function"`, mirroring the pattern in `packages/hatchet/src/metadata/accessor.ts`.
- Added regression tests for `metatype: undefined` and a string-token metatype.

## Test plan

- [x] `yarn workspace @abinnovision/nestjs-healthz test-unit` (29 passed)
- [x] `yarn workspace @abinnovision/nestjs-healthz build`
- [ ] Bump dependency in consumer app and confirm bootstrap completes without the `Reflect.getMetadata` TypeError