### PR TITLE
fix(hatchet): propagate emitBulk options.priority and scope to each input

### DIFF
--- a/packages/hatchet/src/client/client.spec.ts
+++ b/packages/hatchet/src/client/client.spec.ts
@@ -131,6 +131,42 @@ describe("client/client.ts", () => {
 			);
 		});
 
+		it("propagates options.priority and options.scope onto each input", async () => {
+			const options = {
+				additionalMetadata: { tenant: "acme" },
+				priority: 5,
+				scope: "tenant-acme",
+			};
+
+			await client.emitBulk(
+				TestEvent,
+				[
+					{ id: "1", value: 10 },
+					{ id: "2", value: 20 },
+				],
+				options,
+			);
+
+			expect(mockHatchetClient.events.bulkPush).toHaveBeenCalledWith(
+				"test:event",
+				[
+					{
+						payload: { id: "1", value: 10, [EVENT_MARKER]: "test:event" },
+						additionalMetadata: options.additionalMetadata,
+						priority: options.priority,
+						scope: options.scope,
+					},
+					{
+						payload: { id: "2", value: 20, [EVENT_MARKER]: "test:event" },
+						additionalMetadata: options.additionalMetadata,
+						priority: options.priority,
+						scope: options.scope,
+					},
+				],
+				options,
+			);
+		});
+
 		it("returns emitted events", async () => {
 			const mockEvents = [{ eventId: "1" }, { eventId: "2" }];
 			mockHatchetClient.events.bulkPush.mockResolvedValueOnce({

--- a/packages/hatchet/src/client/client.ts
+++ b/packages/hatchet/src/client/client.ts
@@ -81,6 +81,13 @@ export class Client {
 			event.name,
 			inputs.map((input) => ({
 				payload: { ...(input as object), [EVENT_MARKER]: event.name },
+				...(options?.additionalMetadata !== undefined && {
+					additionalMetadata: options.additionalMetadata,
+				}),
+				...(options?.priority !== undefined && {
+					priority: options.priority,
+				}),
+				...(options?.scope !== undefined && { scope: options.scope }),
 			})),
 			options,
 		);


### PR DESCRIPTION
## Summary
- `EventClient.bulkPush` in the Hatchet SDK silently drops options-level `priority` and `scope` (it reads both only from per-input `EventWithMetadata`), so callers using `client.emitBulk(Event, payloads, { priority, scope })` got nothing applied.
- Fan `options.additionalMetadata`, `priority`, and `scope` onto every per-input entry so they actually reach the wire, while still forwarding `options` to the SDK in case a future version honors them.
- Added a unit test asserting each entry carries the propagated metadata.

## Test plan
- [x] `yarn workspace @abinnovision/nestjs-hatchet test-unit` (198 tests pass, no type errors)
- [x] `yarn workspace @abinnovision/nestjs-hatchet build`