### PR TITLE
fix(hatchet): parallelize array run outputs and memoize accessor.methods

### DIFF
--- a/packages/hatchet/src/execution/host-run/adapter-factory.ts
+++ b/packages/hatchet/src/execution/host-run/adapter-factory.ts
@@ -32,17 +32,19 @@ function createHostRunFn(runner: RunnerFn): HostRunFn {
 		const wait = options?.wait ?? true;
 
 		if (Array.isArray(input)) {
-			const results = await Promise.all(
-				(input as InputOfRef<R>[]).map((i) => runner(workflowName, i, options)),
+			const runs = (input as InputOfRef<R>[]).map((i) =>
+				runner(workflowName, i, options),
 			);
 
 			if (wait) {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-				return (await Promise.all(results.map((r) => r.output))) as any;
+				return (await Promise.all(
+					runs.map((p) => p.then((r) => r.output)),
+				)) as any;
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-			return results as any;
+			return (await Promise.all(runs)) as any;
 		}
 
 		const runRef = await runner(workflowName, input, options);

--- a/packages/hatchet/src/metadata/accessor.ts
+++ b/packages/hatchet/src/metadata/accessor.ts
@@ -16,6 +16,13 @@ import type { SdkHostOpts } from "./translator.js";
 import type { AnyHost, AnyHostCtor } from "../references/shared.js";
 
 /**
+ * Cache of decorated method names keyed by host constructor. Decorator
+ * metadata is fixed at class-definition time, so this is safe to memoize for
+ * the lifetime of the constructor.
+ */
+const methodsCache = new WeakMap<AnyHostCtor, string[]>();
+
+/**
  * Accessor for host metadata and methods.
  */
 class HostAccessor {
@@ -48,19 +55,29 @@ class HostAccessor {
 	}
 
 	public get methods(): string[] {
+		const cached = methodsCache.get(this.ctor);
+
+		if (cached !== undefined) {
+			return cached;
+		}
+
 		const markerKey = this.isWorkflow
 			? METADATA_KEY_WORKFLOW_TASK_OPTS
 			: METADATA_KEY_TASK_OPTS;
 
 		const proto = this.ctor.prototype;
 
-		return Object.getOwnPropertyNames(proto)
+		const result = Object.getOwnPropertyNames(proto)
 			.filter(
 				(name) => name !== "constructor" && typeof proto[name] === "function",
 			)
 			.filter(
 				(method) => Reflect.getMetadata(markerKey, proto[method]) !== undefined,
 			);
+
+		methodsCache.set(this.ctor, result);
+
+		return result;
 	}
 
 	public getWorkflowTaskMeta(method: string): WorkflowTaskOpts<any> {


### PR DESCRIPTION
## Summary

Two small, behavior-preserving optimizations in `@abinnovision/nestjs-hatchet`:

- **`adapter-factory.ts`** — when `host.run([...])` is called with `wait: true`, chain `.then(r => r.output)` per item inside a single `Promise.all` so each item's execution-await starts the moment its submission resolves, instead of waiting for the slowest submission in the batch.
- **`accessor.ts`** — memoize `HostAccessor.methods` per constructor via a module-level `WeakMap`. Decorator metadata is fixed at class-definition time, and the getter is hit repeatedly during declaration building.

## Test plan

- [x] `yarn workspace @abinnovision/nestjs-hatchet test-unit` — 198/198 pass
- [x] `yarn workspace @abinnovision/nestjs-hatchet build` — clean, no type errors