### PR TITLE
feat(docs): publish docs app to GitHub Pages

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -27,5 +27,8 @@
 		"postcss": "^8.4.49",
 		"tailwindcss": "^4.0.0",
 		"typescript": "^6.0.3"
+	},
+	"publishConfig": {
+		"platform": "gh-pages"
 	}
 }


### PR DESCRIPTION
## Summary

Adds `publishConfig.platform = "gh-pages"` to `apps/docs/package.json` so the reusable `polyglot-monorepo-stack@v1` workflow discovers the docs app as a gh-pages candidate. With `enable-gh-pages: true` already set in `.github/workflows/build.yaml`, this is the only repo-side change needed; the `publish_gh_pages` job will now run on release commits that bump `apps/docs`.

Repo settings still required (outside this PR): set Pages source to "GitHub Actions" and ensure the `github-pages` environment exists. PR / non-release pushes will not deploy — deployment is gated to release-please-released versions of the docs app.

## Test plan

- [ ] Verify the `Configure` step of the next workflow run on `main` logs `Found 1 gh-pages apps: ["docs"]`.
- [ ] On the next release PR that bumps `apps/docs`, confirm the `Publish / GitHub Pages` job runs and deploys.
- [ ] After deploy, load `https://abinnovision.github.io/nestjs-commons/` and check navigation/assets.