### PR TITLE
fix(release-please): split release PRs per package

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
 	"changelog-path": "CHANGELOG.md",
 	"release-type": "node",
+	"separate-pull-requests": true,
 	"packages": {
 		"packages/configx": {},
 		"packages/exceptions": {},


### PR DESCRIPTION
## Summary

Enables `separate-pull-requests` in `release-please-config.json` so each configured path (`packages/configx`, `packages/exceptions`, `packages/hatchet`, `packages/healthz`, `packages/toolkit`, `apps/docs`) produces its own release PR. This decouples release cadence so a stalled change in one artifact no longer blocks the rest, and keeps the non-publishable docs app off the npm release train.

## Test plan

- [ ] Build workflow runs green on this PR
- [ ] After merge, next release-please run on `main` produces per-package release PRs (titles like `chore(packages/hatchet): release X.Y.Z`) instead of one combined `chore: release main`
- [ ] `.release-please-manifest.json` versions remain unchanged