### PR TITLE
feat(flydrive): add NestJS integration package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,7 @@
 {
 	"packages/configx": "2.0.4",
 	"packages/exceptions": "0.1.0",
+	"packages/flydrive": "0.1.0",
 	"packages/hatchet": "0.7.1",
 	"packages/healthz": "0.1.1",
 	"packages/toolkit": "0.2.0",

--- a/packages/flydrive/LICENSE
+++ b/packages/flydrive/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 abi group GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/flydrive/README.md
+++ b/packages/flydrive/README.md
@@ -1,0 +1,202 @@
+# @abinnovision/nestjs-flydrive
+
+NestJS integration for [flydrive](https://flydrive.dev). Drivers for the
+local filesystem, AWS S3 (incl. R2, Spaces, Supabase), and Google Cloud
+Storage.
+
+Disks are identified by classes, not strings. Each disk is a class
+produced by `defineDisk()` used both as the DI token and as the type at
+injection sites.
+
+## Installation
+
+```bash
+yarn add @abinnovision/nestjs-flydrive
+```
+
+Install only the driver SDKs you actually use:
+
+```bash
+# S3 / R2 / Spaces / Supabase
+yarn add @aws-sdk/client-s3 @aws-sdk/s3-request-presigner
+
+# Google Cloud Storage
+yarn add @google-cloud/storage
+```
+
+`flydrive` is ESM-only and requires Node.js 24 or newer.
+
+## Quick Start
+
+### 1. Declare a disk reference class
+
+```typescript
+import { defineDisk } from "@abinnovision/nestjs-flydrive";
+
+export class UploadsDisk extends defineDisk() {}
+export class BackupsDisk extends defineDisk() {}
+```
+
+### 2. Register the module
+
+```typescript
+import { FlydriveModule } from "@abinnovision/nestjs-flydrive";
+import { FSDriver } from "flydrive/drivers/fs";
+import { S3Driver } from "flydrive/drivers/s3";
+
+@Module({
+  imports: [
+    FlydriveModule.forRoot({
+      default: UploadsDisk,
+      disks: [
+        {
+          ref: UploadsDisk,
+          driver: () =>
+            new FSDriver({
+              location: new URL("./uploads", import.meta.url),
+              visibility: "public",
+            }),
+        },
+        {
+          ref: BackupsDisk,
+          driver: () =>
+            new S3Driver({
+              bucket: process.env.S3_BUCKET!,
+              region: process.env.AWS_REGION!,
+              visibility: "private",
+              credentials: {
+                accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+                secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+              },
+            }),
+        },
+      ],
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+The module is `@Global()`, so disk classes and `DefaultDisk` are
+injectable across the application after a single import.
+
+### 3. Inject and use
+
+```typescript
+import { Injectable } from "@nestjs/common";
+import { DefaultDisk } from "@abinnovision/nestjs-flydrive";
+
+@Injectable()
+export class UploadService {
+  public constructor(
+    private readonly uploads: UploadsDisk,
+    private readonly backups: BackupsDisk,
+    private readonly defaultDisk: DefaultDisk,
+  ) {}
+
+  public async store(key: string, body: Uint8Array): Promise<void> {
+    await this.uploads.put(key, body);
+  }
+}
+```
+
+`DefaultDisk` resolves to whichever class was passed as `default`.
+
+## Async configuration
+
+```typescript
+FlydriveModule.forRootAsync({
+  default: UploadsDisk,
+  disks: [UploadsDisk, BackupsDisk],
+  imports: [StorageConfigModule],
+  inject: [StorageConfig],
+  useFactory: (cfg: StorageConfig) => ({
+    drivers: [
+      {
+        ref: UploadsDisk,
+        driver: () =>
+          new FSDriver({ location: cfg.localPath, visibility: "public" }),
+      },
+      {
+        ref: BackupsDisk,
+        driver: () =>
+          new S3Driver({ bucket: cfg.bucket, region: cfg.region /* ... */ }),
+      },
+    ],
+  }),
+});
+```
+
+`disks` is supplied statically because Nest needs the provider tokens at
+module-definition time, before `useFactory` runs. The refs returned by
+the factory must match `disks` exactly; mismatches throw at startup.
+
+## Lifecycle
+
+- Driver factories run once during `onModuleInit`. A throw aborts the
+  application bootstrap. No retries.
+- Resolving the same ref class always returns the same `Disk` instance.
+- Errors from `Disk` propagate unmodified (flydrive's own `AppError`
+  subclasses).
+
+## Testing
+
+### Swap drivers at runtime with `FlydriveTester`
+
+`FlydriveTester` replaces the driver behind a ref without rebuilding the
+testing module. The injected `Disk` reference keeps its identity.
+
+```typescript
+import { Test } from "@nestjs/testing";
+import { FlydriveTester } from "@abinnovision/nestjs-flydrive";
+import { FSDriver } from "flydrive/drivers/fs";
+
+const moduleRef = await Test.createTestingModule({
+  imports: [AppModule],
+}).compile();
+
+await moduleRef.init();
+
+const tester = moduleRef.get(FlydriveTester);
+
+tester.fake(
+  UploadsDisk,
+  new FSDriver({
+    location: new URL("./tmp/uploads", import.meta.url),
+    visibility: "public",
+  }),
+);
+
+// ... assertions ...
+
+tester.restore(UploadsDisk);
+```
+
+`fake()` also accepts a factory function for deferred construction.
+
+### Standard provider overrides
+
+`overrideProvider` works as usual:
+
+```typescript
+await Test.createTestingModule({ imports: [AppModule] })
+  .overrideProvider(UploadsDisk)
+  .useValue(testDisk)
+  .compile();
+```
+
+## Public API
+
+| Export                      | Role                                                                            |
+| --------------------------- | ------------------------------------------------------------------------------- |
+| `FlydriveModule`            | Module with `forRoot` / `forRootAsync`.                                         |
+| `defineDisk()`              | Factory that creates a fresh disk reference class.                              |
+| `DefaultDisk`               | Token aliasing the ref class chosen as `default`.                               |
+| `DiskRegistry`              | Owns the `Disk` instances. Inject for advanced introspection or scripted use.   |
+| `FlydriveTester`            | Class-keyed `fake()` / `restore()` helper for tests.                            |
+| `flydriveModuleConfigToken` | DI token holding the resolved configuration.                                    |
+| Type re-exports             | All types from `flydrive` and `flydrive/types` (e.g. `Disk`, `DriverContract`). |
+
+## License
+
+Apache-2.0

--- a/packages/flydrive/eslint.config.mts
+++ b/packages/flydrive/eslint.config.mts
@@ -1,0 +1,12 @@
+import {
+	base,
+	configFiles,
+	vitest,
+	stylistic,
+} from "@abinnovision/eslint-config-base";
+import { defineConfig } from "eslint/config";
+
+export default defineConfig([
+	{ extends: [base, vitest, stylistic] },
+	{ files: ["*.{c,m,}{t,j}s"], extends: [configFiles] },
+]);

--- a/packages/flydrive/package.json
+++ b/packages/flydrive/package.json
@@ -1,0 +1,96 @@
+{
+	"$schema": "https://json.schemastore.org/package.json",
+	"name": "@abinnovision/nestjs-flydrive",
+	"version": "0.1.0",
+	"description": "NestJS integration for flydrive with class-token disks, eager fail-fast startup, and a fakes API for tests.",
+	"keywords": [
+		"nestjs",
+		"flydrive",
+		"storage",
+		"filesystem",
+		"s3",
+		"gcs",
+		"r2",
+		"object-storage"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/abinnovision/nestjs-commons.git",
+		"directory": "packages/flydrive"
+	},
+	"license": "Apache-2.0",
+	"author": {
+		"name": "abi group GmbH",
+		"email": "info@abigroup.io",
+		"url": "https://abigroup.io"
+	},
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./dist/index.d.mts",
+				"default": "./dist/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
+		}
+	},
+	"main": "./dist/index.cjs",
+	"types": "./dist/index.d.mts",
+	"files": [
+		"dist",
+		"LICENSE",
+		"README.md"
+	],
+	"scripts": {
+		"build": "tsdown && publint",
+		"format:check": "prettier --check '{{src,test}/**/*,*}.{js,jsx,ts,tsx,json,json5,yml,yaml,md}'",
+		"format:fix": "prettier --write '{{src,test}/**/*,*}.{js,jsx,ts,tsx,json,json5,yml,yaml,md}'",
+		"lint:check": "eslint '{{src,test}/**/*,*}.{js,jsx,ts,tsx}'",
+		"lint:fix": "eslint '{{src,test}/**/*,*}.{js,jsx,ts,tsx}' --fix",
+		"test-unit": "vitest --run --coverage --config vitest.config.mts",
+		"test-unit:watch": "vitest --config vitest.config.mts"
+	},
+	"lint-staged": {
+		"src/**/*.{ts,js}": [
+			"eslint --fix",
+			"prettier --write"
+		],
+		"*.{js,ts,json,json5,yaml,yml,md}": [
+			"prettier --write"
+		]
+	},
+	"prettier": "@abinnovision/prettier-config",
+	"dependencies": {
+		"flydrive": "^2.1.0"
+	},
+	"devDependencies": {
+		"@abinnovision/eslint-config-base": "^3.4.1",
+		"@abinnovision/prettier-config": "^2.2.0",
+		"@nestjs/common": "^11.0.0",
+		"@nestjs/core": "^11.0.0",
+		"@nestjs/testing": "^11.0.0",
+		"@swc/core": "^1.15.18",
+		"@types/node": "^25.8.0",
+		"eslint": "^10.3.0",
+		"prettier": "^3.8.3",
+		"publint": "^0.3.21",
+		"reflect-metadata": "^0.2.2",
+		"rxjs": "^7.8.2",
+		"tsdown": "^0.22.0",
+		"typescript": "^6.0.3",
+		"unplugin-swc": "^1.5.9",
+		"vitest": "^4.1.6"
+	},
+	"peerDependencies": {
+		"@nestjs/common": "^11.0.0",
+		"@nestjs/core": "^11.0.0"
+	},
+	"publishConfig": {
+		"ghpr": true,
+		"npm": true,
+		"npmAccess": "public"
+	}
+}

--- a/packages/flydrive/src/default-disk.ts
+++ b/packages/flydrive/src/default-disk.ts
@@ -1,0 +1,24 @@
+import { defineDisk } from "./disk-ref.js";
+
+/**
+ * Marker token resolving to whichever disk is configured as the module's
+ * `default`.
+ *
+ * Inject this when you want the default disk without naming a specific ref
+ * class:
+ *
+ * ```ts
+ * @Injectable()
+ * export class UploadService {
+ *   constructor(private readonly disk: DefaultDisk) {}
+ * }
+ * ```
+ *
+ * The module aliases this token to the user's chosen `default` ref via a
+ * `useExisting` provider, so `DefaultDisk` and the chosen ref class always
+ * resolve to the same `Disk` instance.
+ *
+ * Do not declare your own class named `DefaultDisk` in consumer code:
+ * shadowing this export silently breaks the alias.
+ */
+export abstract class DefaultDisk extends defineDisk() {}

--- a/packages/flydrive/src/disk-ref.spec.ts
+++ b/packages/flydrive/src/disk-ref.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { defineDisk } from "./disk-ref.js";
+
+describe("defineDisk()", () => {
+	it("returns a unique class for each call", () => {
+		const A = defineDisk();
+		const B = defineDisk();
+
+		expect(A).not.toBe(B);
+	});
+
+	it("preserves class identity across uses (same reference is reused)", () => {
+		const A = defineDisk();
+		const Alias = A;
+
+		expect(A === Alias).toBe(true);
+	});
+
+	it("can be extended into a concrete reference class", () => {
+		class UploadsDisk extends defineDisk() {}
+
+		expect(typeof UploadsDisk).toBe("function");
+	});
+
+	it("throws at runtime if a subclass is instantiated directly", () => {
+		class UploadsDisk extends defineDisk() {}
+
+		// Bypass the abstract type-level constraint to exercise the runtime guard.
+		const Ctor = UploadsDisk as unknown as new () => unknown;
+
+		expect(() => new Ctor()).toThrow(/cannot be instantiated/i);
+	});
+
+	it("does not read or rely on the class name (identity is by reference)", () => {
+		const A = defineDisk();
+		const B = defineDisk();
+
+		expect((A as { name?: string }).name).toBe((B as { name?: string }).name);
+		expect(A).not.toBe(B);
+	});
+});

--- a/packages/flydrive/src/disk-ref.ts
+++ b/packages/flydrive/src/disk-ref.ts
@@ -1,0 +1,48 @@
+import type { Disk } from "flydrive";
+
+/**
+ * Constructor type for disk reference classes produced by `defineDisk()`.
+ *
+ * The instance type is `Disk` so that injected fields typed by a ref class
+ * (e.g. `private readonly uploads: UploadsDisk`) expose the full `Disk`
+ * API directly. The constructor signature is `abstract`, so attempting
+ * `new UploadsDisk()` fails at compile time.
+ */
+export type DiskRefClass = abstract new () => Disk;
+
+/**
+ * Creates an abstract class to serve as a disk reference token.
+ *
+ * Typical usage:
+ *
+ * ```ts
+ * import { defineDisk } from "@abinnovision/nestjs-flydrive";
+ *
+ * export class UploadsDisk extends defineDisk() {}
+ * export class BackupsDisk extends defineDisk() {}
+ * ```
+ *
+ * The returned class is used in three ways:
+ *
+ * 1. As the DI token passed in `FlydriveModule.forRoot({ disks: [...] })`.
+ * 2. As the type at injection sites; the field resolves to `Disk`, so
+ *    methods like `put`, `get`, `getSignedUrl` are available directly.
+ * 3. As the identity the module uses to look up the driver. Equality is
+ *    by constructor reference, never by name, so minification is safe.
+ *
+ * Calling `new UploadsDisk()` is a compile-time error. The runtime
+ * constructor throws as a fallback if a caller bypasses the type system.
+ */
+export function defineDisk(): DiskRefClass {
+	// eslint-disable-next-line @typescript-eslint/no-extraneous-class -- This class exists only as a unique DI token identity; instance shape is unused.
+	class DiskRef {
+		public constructor() {
+			throw new Error(
+				"Classes returned by `defineDisk()` are DI tokens and cannot be instantiated. " +
+					"Inject the class instead of calling `new` on it.",
+			);
+		}
+	}
+
+	return DiskRef as unknown as DiskRefClass;
+}

--- a/packages/flydrive/src/disk-registry.ts
+++ b/packages/flydrive/src/disk-registry.ts
@@ -1,0 +1,83 @@
+import { Inject, Injectable } from "@nestjs/common";
+
+import { flydriveModuleConfigToken } from "./flydrive.module-config.js";
+import { SwappableDisk } from "./internal/swappable-disk.js";
+
+import type { DiskRefClass } from "./disk-ref.js";
+import type { ResolvedFlydriveConfig } from "./flydrive.module-config.js";
+import type { OnModuleInit } from "@nestjs/common";
+import type { Disk } from "flydrive";
+import type { DriverContract } from "flydrive/types";
+
+/**
+ * Owns the `Disk` instances behind every registered ref class.
+ *
+ * Every driver is constructed during `onModuleInit` so misconfiguration
+ * surfaces at application startup. Construction happens at most once per
+ * ref; subsequent `resolve()` calls return the cached instance.
+ *
+ * Each `Disk` is wrapped in a {@link SwappableDisk} so the fakes API can
+ * swap the driver at runtime without invalidating already-injected
+ * references.
+ */
+@Injectable()
+export class DiskRegistry implements OnModuleInit {
+	private readonly disks = new Map<DiskRefClass, SwappableDisk>();
+
+	public constructor(
+		@Inject(flydriveModuleConfigToken)
+		private readonly config: ResolvedFlydriveConfig,
+	) {}
+
+	public onModuleInit(): void {
+		for (const entry of this.config.disks) {
+			this.ensure(entry.ref);
+		}
+	}
+
+	/**
+	 * Resolve the `Disk` instance associated with a ref class.
+	 *
+	 * Throws if the ref is not registered with the module.
+	 */
+	public resolve(ref: DiskRefClass): Disk {
+		return this.ensure(ref).disk;
+	}
+
+	/**
+	 * Replace the driver behind a ref. Used by {@link FlydriveTester.fake}.
+	 */
+	public swap(ref: DiskRefClass, driver: DriverContract): void {
+		this.ensure(ref).swap(driver);
+	}
+
+	/**
+	 * Restore the original driver for a ref.
+	 */
+	public restore(ref: DiskRefClass): void {
+		this.ensure(ref).restore();
+	}
+
+	private ensure(ref: DiskRefClass): SwappableDisk {
+		const existing = this.disks.get(ref);
+
+		if (existing !== undefined) {
+			return existing;
+		}
+
+		const entry = this.config.disks.find((d) => d.ref === ref);
+
+		if (entry === undefined) {
+			throw new Error(
+				"FlydriveModule: requested disk reference is not registered. " +
+					"Ensure the ref class is listed in `FlydriveModule.forRoot({ disks })`.",
+			);
+		}
+
+		const swappable = new SwappableDisk(entry.driver());
+
+		this.disks.set(ref, swappable);
+
+		return swappable;
+	}
+}

--- a/packages/flydrive/src/flydrive-tester.ts
+++ b/packages/flydrive/src/flydrive-tester.ts
@@ -1,0 +1,59 @@
+import { Injectable } from "@nestjs/common";
+
+import { DiskRegistry } from "./disk-registry.js";
+
+import type { DiskRefClass } from "./disk-ref.js";
+import type { DriverContract } from "flydrive/types";
+
+/**
+ * Test helper for swapping a disk's driver at runtime.
+ *
+ * Intended for integration / E2E tests where you want to replace one disk
+ * (e.g. an S3 disk pointing at AWS) with a local-filesystem-backed driver
+ * without rebuilding the testing module:
+ *
+ * ```ts
+ * const tester = app.get(FlydriveTester);
+ *
+ * tester.fake(UploadsDisk, new FSDriver({
+ *   location: new URL("./tmp", import.meta.url),
+ *   visibility: "public",
+ * }));
+ *
+ * // ... assertions ...
+ *
+ * tester.restore(UploadsDisk);
+ * ```
+ *
+ * Standard `overrideProvider(UploadsDisk).useValue(...)` continues to work
+ * for tests that prefer compile-time overrides.
+ */
+@Injectable()
+export class FlydriveTester {
+	public constructor(private readonly registry: DiskRegistry) {}
+
+	/**
+	 * Swap the driver behind a disk reference. The injected `Disk` value
+	 * keeps its object identity; only its internal driver changes, so
+	 * already-resolved consumers transparently see the new behaviour.
+	 *
+	 * `driver` accepts either a ready-built `DriverContract` instance or a
+	 * factory function. The factory form is useful when driver construction
+	 * should be deferred inside a test setup hook.
+	 */
+	public fake(
+		ref: DiskRefClass,
+		driver: DriverContract | (() => DriverContract),
+	): void {
+		const resolved = typeof driver === "function" ? driver() : driver;
+
+		this.registry.swap(ref, resolved);
+	}
+
+	/**
+	 * Restore the disk's original driver, undoing a prior `fake()` call.
+	 */
+	public restore(ref: DiskRefClass): void {
+		this.registry.restore(ref);
+	}
+}

--- a/packages/flydrive/src/flydrive.module-config.ts
+++ b/packages/flydrive/src/flydrive.module-config.ts
@@ -1,0 +1,110 @@
+import type { DiskRefClass } from "./disk-ref.js";
+import type { FactoryProvider, ModuleMetadata } from "@nestjs/common";
+import type { DriverContract } from "flydrive/types";
+
+/**
+ * A single disk registration: which ref class identifies it, and how to
+ * build its underlying flydrive driver.
+ */
+export interface FlydriveDiskEntry<Refs extends readonly DiskRefClass[]> {
+	/**
+	 * Disk reference class. Must appear in the surrounding `disks` list.
+	 */
+	ref: Refs[number];
+
+	/**
+	 * Builder for the flydrive driver. Called at most once per disk: either
+	 * eagerly during `onModuleInit` (default) or lazily on first resolution
+	 * when `lazy: true`. Errors thrown here propagate to the application
+	 * bootstrap.
+	 */
+	driver: () => DriverContract;
+}
+
+/**
+ * Options accepted by `FlydriveModule.forRoot`.
+ */
+export interface FlydriveModuleOptions<Refs extends readonly DiskRefClass[]> {
+	/**
+	 * Disk to resolve when `DefaultDisk` is injected. Must be one of the
+	 * classes in `disks`.
+	 */
+	default: Refs[number];
+
+	/**
+	 * Every disk the module should register.
+	 */
+	disks: readonly FlydriveDiskEntry<Refs>[];
+}
+
+/**
+ * Shape returned by `FlydriveModule.forRootAsync`'s `useFactory`.
+ */
+export interface FlydriveAsyncFactoryResult<
+	Refs extends readonly DiskRefClass[],
+> {
+	/**
+	 * Driver builders for every disk declared in the outer options. The set
+	 * of `ref`s must match the static `disks` list exactly; mismatches throw
+	 * before the resolved config is published to the DI container.
+	 */
+	drivers: readonly FlydriveDiskEntry<Refs>[];
+}
+
+/**
+ * Options accepted by `FlydriveModule.forRootAsync`.
+ */
+export interface FlydriveModuleAsyncOptions<
+	Refs extends readonly DiskRefClass[],
+> {
+	/**
+	 * Disk to resolve when `DefaultDisk` is injected. Must be one of the
+	 * classes in `disks`.
+	 */
+	default: Refs[number];
+
+	/**
+	 * Disk reference classes registered with this module. Supplied
+	 * statically because Nest needs to register a provider per class at
+	 * module-definition time, before the async factory resolves.
+	 */
+	disks: Refs;
+
+	imports?: ModuleMetadata["imports"];
+
+	inject?: FactoryProvider["inject"];
+
+	/**
+	 * Builds the resolved driver list. Receives the dependencies declared in
+	 * `inject` in the usual NestJS order. The returned `drivers` array must
+	 * have exactly one entry per ref class in `disks`.
+	 */
+	useFactory: (
+		...args: any[]
+	) =>
+		| Promise<FlydriveAsyncFactoryResult<Refs>>
+		| FlydriveAsyncFactoryResult<Refs>;
+}
+
+/**
+ * Resolved configuration shape stored under {@link flydriveModuleConfigToken}.
+ *
+ * Both sync and async paths normalise to this shape before publishing the
+ * value to the DI container, so providers depending on the token see a
+ * single, consistent type regardless of how the module was wired.
+ */
+export interface ResolvedFlydriveConfig {
+	default: DiskRefClass;
+	disks: ReadonlyArray<FlydriveDiskEntry<readonly DiskRefClass[]>>;
+}
+
+/**
+ * DI token holding the resolved {@link ResolvedFlydriveConfig}.
+ *
+ * Exposed for advanced consumers (e.g. building custom providers on top of
+ * the module). Most code should inject disk ref classes or
+ * {@link DefaultDisk} instead.
+ */
+export const flydriveModuleConfigToken: unique symbol = Symbol(
+	"flydrive:module:config",
+);

--- a/packages/flydrive/src/flydrive.module.spec.ts
+++ b/packages/flydrive/src/flydrive.module.spec.ts
@@ -1,0 +1,272 @@
+import { Test } from "@nestjs/testing";
+import { Disk } from "flydrive";
+import { describe, expect, it, vi } from "vitest";
+
+import { DefaultDisk } from "./default-disk.js";
+import { defineDisk } from "./disk-ref.js";
+import { FlydriveTester } from "./flydrive-tester.js";
+import { FlydriveModule } from "./flydrive.module.js";
+
+import type { DriverContract } from "flydrive/types";
+
+class UploadsDisk extends defineDisk() {}
+class BackupsDisk extends defineDisk() {}
+class ReportsDisk extends defineDisk() {}
+
+function makeDriver(label: string): DriverContract & { label: string } {
+	return {
+		label,
+		exists: vi.fn().mockResolvedValue(false),
+		put: vi.fn().mockResolvedValue(undefined),
+		putStream: vi.fn().mockResolvedValue(undefined),
+		get: vi.fn().mockResolvedValue(""),
+		getStream: vi.fn(),
+		getBytes: vi.fn().mockResolvedValue(new Uint8Array()),
+		delete: vi.fn().mockResolvedValue(undefined),
+		deleteAll: vi.fn().mockResolvedValue(undefined),
+		copy: vi.fn().mockResolvedValue(undefined),
+		move: vi.fn().mockResolvedValue(undefined),
+		getMetaData: vi.fn().mockResolvedValue({}),
+		listAll: vi.fn().mockResolvedValue({ objects: [], directories: [] }),
+		getVisibility: vi.fn().mockResolvedValue("private"),
+		setVisibility: vi.fn().mockResolvedValue(undefined),
+		getUrl: vi.fn().mockResolvedValue(""),
+		getSignedUrl: vi.fn().mockResolvedValue(""),
+		getSignedUploadUrl: vi.fn().mockResolvedValue(""),
+	} as unknown as DriverContract & { label: string };
+}
+
+describe("flydriveModule.forRoot", () => {
+	it("resolves each registered disk class to a working Disk", async () => {
+		const uploadsDriver = makeDriver("uploads");
+		const backupsDriver = makeDriver("backups");
+
+		const moduleRef = await Test.createTestingModule({
+			imports: [
+				FlydriveModule.forRoot({
+					default: UploadsDisk,
+					disks: [
+						{ ref: UploadsDisk, driver: () => uploadsDriver },
+						{ ref: BackupsDisk, driver: () => backupsDriver },
+					],
+				}),
+			],
+		}).compile();
+
+		await moduleRef.init();
+
+		const uploads = moduleRef.get(UploadsDisk);
+		const backups = moduleRef.get(BackupsDisk);
+
+		expect(uploads).toBeInstanceOf(Disk);
+		expect(backups).toBeInstanceOf(Disk);
+		expect(uploads).not.toBe(backups);
+
+		await moduleRef.close();
+	});
+
+	it("aliases DefaultDisk to the configured default ref", async () => {
+		const moduleRef = await Test.createTestingModule({
+			imports: [
+				FlydriveModule.forRoot({
+					default: UploadsDisk,
+					disks: [
+						{ ref: UploadsDisk, driver: () => makeDriver("uploads") },
+						{ ref: BackupsDisk, driver: () => makeDriver("backups") },
+					],
+				}),
+			],
+		}).compile();
+
+		await moduleRef.init();
+
+		const fromDefault = moduleRef.get(DefaultDisk);
+		const fromRef = moduleRef.get(UploadsDisk);
+
+		expect(fromDefault).toBe(fromRef);
+
+		await moduleRef.close();
+	});
+
+	it("constructs every driver eagerly during onModuleInit by default", async () => {
+		const uploadsFactory = vi.fn(() => makeDriver("uploads"));
+		const backupsFactory = vi.fn(() => makeDriver("backups"));
+
+		const moduleRef = await Test.createTestingModule({
+			imports: [
+				FlydriveModule.forRoot({
+					default: UploadsDisk,
+					disks: [
+						{ ref: UploadsDisk, driver: uploadsFactory },
+						{ ref: BackupsDisk, driver: backupsFactory },
+					],
+				}),
+			],
+		}).compile();
+
+		await moduleRef.init();
+
+		expect(uploadsFactory).toHaveBeenCalledTimes(1);
+		expect(backupsFactory).toHaveBeenCalledTimes(1);
+
+		await moduleRef.close();
+	});
+
+	it("invokes each driver factory exactly once even when injected", async () => {
+		const uploadsFactory = vi.fn(() => makeDriver("uploads"));
+		const backupsFactory = vi.fn(() => makeDriver("backups"));
+
+		const moduleRef = await Test.createTestingModule({
+			imports: [
+				FlydriveModule.forRoot({
+					default: UploadsDisk,
+					disks: [
+						{ ref: UploadsDisk, driver: uploadsFactory },
+						{ ref: BackupsDisk, driver: backupsFactory },
+					],
+				}),
+			],
+		}).compile();
+
+		await moduleRef.init();
+
+		moduleRef.get(UploadsDisk);
+		moduleRef.get(BackupsDisk);
+
+		expect(uploadsFactory).toHaveBeenCalledTimes(1);
+		expect(backupsFactory).toHaveBeenCalledTimes(1);
+
+		await moduleRef.close();
+	});
+
+	it("throws synchronously when default is not in disks", () => {
+		expect(() =>
+			FlydriveModule.forRoot({
+				default: ReportsDisk,
+				disks: [{ ref: UploadsDisk, driver: () => makeDriver("uploads") }],
+			}),
+		).toThrow(/`default`.*must be one of the registered/i);
+	});
+
+	it("throws synchronously when a ref is registered twice", () => {
+		expect(() =>
+			FlydriveModule.forRoot({
+				default: UploadsDisk,
+				disks: [
+					{ ref: UploadsDisk, driver: () => makeDriver("a") },
+					{ ref: UploadsDisk, driver: () => makeDriver("b") },
+				],
+			}),
+		).toThrow(/duplicate/i);
+	});
+});
+
+describe("flydriveModule.forRootAsync", () => {
+	it("resolves disks from an async factory", async () => {
+		const moduleRef = await Test.createTestingModule({
+			imports: [
+				FlydriveModule.forRootAsync({
+					default: UploadsDisk,
+					disks: [UploadsDisk, BackupsDisk],
+					useFactory: () =>
+						Promise.resolve({
+							drivers: [
+								{ ref: UploadsDisk, driver: () => makeDriver("uploads") },
+								{ ref: BackupsDisk, driver: () => makeDriver("backups") },
+							],
+						}),
+				}),
+			],
+		}).compile();
+
+		await moduleRef.init();
+
+		const uploads = moduleRef.get(UploadsDisk);
+		const backups = moduleRef.get(BackupsDisk);
+		const defaultDisk = moduleRef.get(DefaultDisk);
+
+		expect(uploads).toBeInstanceOf(Disk);
+		expect(backups).toBeInstanceOf(Disk);
+		expect(defaultDisk).toBe(uploads);
+
+		await moduleRef.close();
+	});
+
+	it("throws at compile time of the testing module when driver set does not match declared disks", async () => {
+		const compile = Test.createTestingModule({
+			imports: [
+				FlydriveModule.forRootAsync({
+					default: UploadsDisk,
+					disks: [UploadsDisk, BackupsDisk],
+					useFactory: () => ({
+						drivers: [
+							{ ref: UploadsDisk, driver: () => makeDriver("uploads") },
+							// BackupsDisk missing
+						],
+					}),
+				}),
+			],
+		}).compile();
+
+		await expect(compile).rejects.toThrow(/missing driver/i);
+	});
+});
+
+describe("flydriveTester", () => {
+	it("swaps the driver behind a ref and restores it", async () => {
+		const original = makeDriver("original");
+		const replacement = makeDriver("replacement");
+
+		const moduleRef = await Test.createTestingModule({
+			imports: [
+				FlydriveModule.forRoot({
+					default: UploadsDisk,
+					disks: [{ ref: UploadsDisk, driver: () => original }],
+				}),
+			],
+		}).compile();
+
+		await moduleRef.init();
+
+		const disk = moduleRef.get(UploadsDisk);
+		const tester = moduleRef.get(FlydriveTester);
+
+		await disk.exists("a.txt");
+		expect(original.exists).toHaveBeenCalledWith("a.txt");
+
+		tester.fake(UploadsDisk, replacement);
+		await disk.exists("b.txt");
+		expect(replacement.exists).toHaveBeenCalledWith("b.txt");
+
+		tester.restore(UploadsDisk);
+		await disk.exists("c.txt");
+		expect(original.exists).toHaveBeenCalledWith("c.txt");
+
+		await moduleRef.close();
+	});
+
+	it("accepts a factory for the replacement driver", async () => {
+		const original = makeDriver("original");
+		const replacement = makeDriver("replacement");
+
+		const moduleRef = await Test.createTestingModule({
+			imports: [
+				FlydriveModule.forRoot({
+					default: UploadsDisk,
+					disks: [{ ref: UploadsDisk, driver: () => original }],
+				}),
+			],
+		}).compile();
+
+		await moduleRef.init();
+
+		const disk = moduleRef.get(UploadsDisk);
+		const tester = moduleRef.get(FlydriveTester);
+
+		tester.fake(UploadsDisk, () => replacement);
+		await disk.exists("d.txt");
+		expect(replacement.exists).toHaveBeenCalledWith("d.txt");
+
+		await moduleRef.close();
+	});
+});

--- a/packages/flydrive/src/flydrive.module.ts
+++ b/packages/flydrive/src/flydrive.module.ts
@@ -1,0 +1,159 @@
+import { Global, Module } from "@nestjs/common";
+
+import { DefaultDisk } from "./default-disk.js";
+import { DiskRegistry } from "./disk-registry.js";
+import { FlydriveTester } from "./flydrive-tester.js";
+import { flydriveModuleConfigToken } from "./flydrive.module-config.js";
+import { buildPerDiskProviders } from "./internal/per-disk-providers.js";
+import {
+	assertDefaultInDisks,
+	assertDriversMatchDisks,
+	assertNoDuplicateRefs,
+} from "./internal/validation.js";
+
+import type { DiskRefClass } from "./disk-ref.js";
+import type {
+	FlydriveModuleAsyncOptions,
+	FlydriveModuleOptions,
+	ResolvedFlydriveConfig,
+} from "./flydrive.module-config.js";
+import type { DynamicModule, Provider } from "@nestjs/common";
+
+/**
+ * Create a `useExisting` alias so injecting {@link DefaultDisk} resolves to
+ * the same instance as the user's chosen `default` ref class.
+ */
+function defaultDiskAliasProvider(defaultRef: DiskRefClass): Provider {
+	return { provide: DefaultDisk, useExisting: defaultRef };
+}
+
+/**
+ * NestJS module wrapping the `flydrive` library with class-token DI.
+ *
+ * Disks are declared via classes produced by `defineDisk()` and registered
+ * with this module via `forRoot` or `forRootAsync`. Injecting the class
+ * directly resolves to the matching `Disk` instance:
+ *
+ * ```ts
+ * class UploadsDisk extends defineDisk() {}
+ *
+ * @Module({
+ *   imports: [
+ *     FlydriveModule.forRoot({
+ *       default: UploadsDisk,
+ *       disks: [{ ref: UploadsDisk, driver: () => new FSDriver(...) }],
+ *     }),
+ *   ],
+ * })
+ * export class AppModule {}
+ *
+ * @Injectable()
+ * export class UploadService {
+ *   constructor(private readonly uploads: UploadsDisk) {}
+ * }
+ * ```
+ *
+ * The module is `@Global()`. Registering it once at the root makes every
+ * disk ref class and the {@link DefaultDisk} alias available across the
+ * application without re-importing.
+ */
+@Global()
+@Module({})
+export class FlydriveModule {
+	/**
+	 * Register the module with a synchronously-known set of disks.
+	 *
+	 * Use this when driver construction does not depend on any other
+	 * Nest-managed service; otherwise prefer {@link FlydriveModule.forRootAsync}.
+	 */
+	public static forRoot<const Refs extends readonly DiskRefClass[]>(
+		options: FlydriveModuleOptions<Refs>,
+	): DynamicModule {
+		const refs = options.disks.map((entry) => entry.ref);
+
+		assertNoDuplicateRefs(refs);
+		assertDefaultInDisks(options.default, refs);
+
+		const resolved: ResolvedFlydriveConfig = {
+			default: options.default,
+			disks: options.disks,
+		};
+
+		return {
+			module: FlydriveModule,
+			global: true,
+			providers: [
+				{ provide: flydriveModuleConfigToken, useValue: resolved },
+				DiskRegistry,
+				...buildPerDiskProviders(refs),
+				defaultDiskAliasProvider(options.default),
+				FlydriveTester,
+			],
+			exports: [
+				DiskRegistry,
+				DefaultDisk,
+				FlydriveTester,
+				flydriveModuleConfigToken,
+				...refs,
+			],
+		};
+	}
+
+	/**
+	 * Register the module with driver builders that are resolved from a
+	 * Nest-managed dependency (e.g. a configuration service).
+	 *
+	 * The ref classes themselves are passed statically in `disks` because
+	 * Nest needs to register a provider per class at module-definition time,
+	 * before the async factory runs. The factory must then return one
+	 * driver builder per declared ref. Mismatches throw synchronously,
+	 * before the resolved configuration is published to the DI container.
+	 */
+	public static forRootAsync<const Refs extends readonly DiskRefClass[]>(
+		options: FlydriveModuleAsyncOptions<Refs>,
+	): DynamicModule {
+		const refs = [...options.disks];
+
+		assertNoDuplicateRefs(refs);
+		assertDefaultInDisks(options.default, refs);
+
+		const userFactory = options.useFactory;
+
+		const configProvider: Provider = {
+			provide: flydriveModuleConfigToken,
+			useFactory: async (
+				...deps: readonly unknown[]
+			): Promise<ResolvedFlydriveConfig> => {
+				const result = await userFactory(...(deps as unknown[]));
+
+				assertDriversMatchDisks(refs, result.drivers);
+
+				return {
+					default: options.default,
+					disks: result.drivers,
+				};
+			},
+			inject: options.inject ?? [],
+		};
+
+		return {
+			module: FlydriveModule,
+			global: true,
+			imports: options.imports ?? [],
+			providers: [
+				configProvider,
+				DiskRegistry,
+				...buildPerDiskProviders(refs),
+				defaultDiskAliasProvider(options.default),
+				FlydriveTester,
+			],
+			exports: [
+				DiskRegistry,
+				DefaultDisk,
+				FlydriveTester,
+				flydriveModuleConfigToken,
+				...refs,
+			],
+		};
+	}
+}

--- a/packages/flydrive/src/index.ts
+++ b/packages/flydrive/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./default-disk.js";
+export * from "./disk-ref.js";
+export * from "./disk-registry.js";
+export * from "./flydrive-tester.js";
+export * from "./flydrive.module.js";
+export * from "./flydrive.module-config.js";

--- a/packages/flydrive/src/internal/per-disk-providers.ts
+++ b/packages/flydrive/src/internal/per-disk-providers.ts
@@ -1,0 +1,22 @@
+import { DiskRegistry } from "../disk-registry.js";
+
+import type { DiskRefClass } from "../disk-ref.js";
+import type { Provider } from "@nestjs/common";
+
+/**
+ * Build one provider per registered ref class.
+ *
+ * Each provider resolves the disk via the {@link DiskRegistry}, which owns
+ * memoisation and the swappable-driver wrapper used by the fakes API.
+ */
+export function buildPerDiskProviders(
+	refs: readonly DiskRefClass[],
+): Provider[] {
+	return refs.map(
+		(ref): Provider => ({
+			provide: ref,
+			useFactory: (registry: DiskRegistry) => registry.resolve(ref),
+			inject: [DiskRegistry],
+		}),
+	);
+}

--- a/packages/flydrive/src/internal/swappable-disk.spec.ts
+++ b/packages/flydrive/src/internal/swappable-disk.spec.ts
@@ -1,0 +1,83 @@
+import { Disk } from "flydrive";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SwappableDisk } from "./swappable-disk.js";
+
+import type { DriverContract } from "flydrive/types";
+
+/**
+ * Minimal stub driver that records calls so we can verify which underlying
+ * driver actually serviced a Disk method.
+ */
+function makeDriver(label: string): DriverContract & { label: string } {
+	const exists = vi.fn().mockResolvedValue(false);
+
+	return {
+		label,
+		exists,
+		put: vi.fn().mockResolvedValue(undefined),
+		putStream: vi.fn().mockResolvedValue(undefined),
+		get: vi.fn().mockResolvedValue(""),
+		getStream: vi.fn(),
+		getBytes: vi.fn().mockResolvedValue(new Uint8Array()),
+		delete: vi.fn().mockResolvedValue(undefined),
+		deleteAll: vi.fn().mockResolvedValue(undefined),
+		copy: vi.fn().mockResolvedValue(undefined),
+		move: vi.fn().mockResolvedValue(undefined),
+		getMetaData: vi.fn().mockResolvedValue({}),
+		listAll: vi.fn().mockResolvedValue({ objects: [], directories: [] }),
+		getVisibility: vi.fn().mockResolvedValue("private"),
+		setVisibility: vi.fn().mockResolvedValue(undefined),
+		getUrl: vi.fn().mockResolvedValue(""),
+		getSignedUrl: vi.fn().mockResolvedValue(""),
+		getSignedUploadUrl: vi.fn().mockResolvedValue(""),
+	} as unknown as DriverContract & { label: string };
+}
+
+describe("swappableDisk", () => {
+	let originalDriver: ReturnType<typeof makeDriver>;
+	let swappable: SwappableDisk;
+
+	beforeEach(() => {
+		originalDriver = makeDriver("original");
+		swappable = new SwappableDisk(originalDriver);
+	});
+
+	it("exposes a Proxy that passes `instanceof Disk`", () => {
+		expect(swappable.disk).toBeInstanceOf(Disk);
+	});
+
+	it("forwards method calls to the original driver until swapped", async () => {
+		await swappable.disk.exists("a.txt");
+
+		expect(originalDriver.exists).toHaveBeenCalledWith("a.txt");
+	});
+
+	it("routes calls to the swapped driver after `swap()`", async () => {
+		const replacement = makeDriver("replacement");
+
+		swappable.swap(replacement);
+		await swappable.disk.exists("b.txt");
+
+		expect(replacement.exists).toHaveBeenCalledWith("b.txt");
+		expect(originalDriver.exists).not.toHaveBeenCalled();
+	});
+
+	it("keeps the same proxy reference across swaps", () => {
+		const before = swappable.disk;
+		swappable.swap(makeDriver("two"));
+		const after = swappable.disk;
+
+		expect(before).toBe(after);
+	});
+
+	it("restores the original driver after `restore()`", async () => {
+		const replacement = makeDriver("replacement");
+		swappable.swap(replacement);
+
+		swappable.restore();
+		await swappable.disk.exists("c.txt");
+
+		expect(originalDriver.exists).toHaveBeenCalledWith("c.txt");
+	});
+});

--- a/packages/flydrive/src/internal/swappable-disk.ts
+++ b/packages/flydrive/src/internal/swappable-disk.ts
@@ -1,0 +1,47 @@
+import { Disk } from "flydrive";
+
+import type { DriverContract } from "flydrive/types";
+
+/**
+ * Wraps a `Disk` so its underlying driver can be replaced at runtime
+ * without invalidating already-injected references.
+ *
+ * The `disk` field is a Proxy whose target is a real `Disk`, so the
+ * prototype chain (and therefore `instanceof Disk`) is preserved.
+ * Property reads route through the current inner disk. Swapping the
+ * driver replaces the inner disk; consumers holding a reference to
+ * `disk` see the new driver on the next call without refetching.
+ */
+export class SwappableDisk {
+	public readonly disk: Disk;
+	private readonly originalDriver: DriverContract;
+	private currentDisk: Disk;
+
+	public constructor(driver: DriverContract) {
+		this.originalDriver = driver;
+		this.currentDisk = new Disk(driver);
+
+		this.disk = new Proxy(this.currentDisk, {
+			get: (_target, prop): unknown => {
+				const value: unknown = Reflect.get(
+					this.currentDisk,
+					prop,
+					this.currentDisk,
+				);
+
+				return typeof value === "function"
+					? value.bind(this.currentDisk)
+					: value;
+			},
+			getPrototypeOf: () => Disk.prototype,
+		});
+	}
+
+	public swap(driver: DriverContract): void {
+		this.currentDisk = new Disk(driver);
+	}
+
+	public restore(): void {
+		this.currentDisk = new Disk(this.originalDriver);
+	}
+}

--- a/packages/flydrive/src/internal/validation.spec.ts
+++ b/packages/flydrive/src/internal/validation.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { defineDisk } from "../disk-ref.js";
+import {
+	assertDefaultInDisks,
+	assertDriversMatchDisks,
+	assertNoDuplicateRefs,
+} from "./validation.js";
+
+import type { DiskRefClass } from "../disk-ref.js";
+import type { FlydriveDiskEntry } from "../flydrive.module-config.js";
+
+class Uploads extends defineDisk() {}
+class Backups extends defineDisk() {}
+class Reports extends defineDisk() {}
+
+function entry(ref: DiskRefClass): FlydriveDiskEntry<readonly DiskRefClass[]> {
+	return {
+		ref,
+		driver: () => {
+			throw new Error("driver factory not expected to run in this test");
+		},
+	};
+}
+
+describe("assertNoDuplicateRefs()", () => {
+	it("does not throw when every ref is unique", () => {
+		expect(() => {
+			assertNoDuplicateRefs([Uploads, Backups, Reports]);
+		}).not.toThrow();
+	});
+
+	it("throws when a ref appears more than once", () => {
+		expect(() => {
+			assertNoDuplicateRefs([Uploads, Backups, Uploads]);
+		}).toThrow(/duplicate/i);
+	});
+});
+
+describe("assertDefaultInDisks()", () => {
+	it("does not throw when the default ref is present", () => {
+		expect(() => {
+			assertDefaultInDisks(Uploads, [Uploads, Backups]);
+		}).not.toThrow();
+	});
+
+	it("throws when the default ref is missing from the list", () => {
+		expect(() => {
+			assertDefaultInDisks(Reports, [Uploads, Backups]);
+		}).toThrow(/`default`.*must be one of the registered/i);
+	});
+});
+
+describe("assertDriversMatchDisks()", () => {
+	it("does not throw when declared and returned sets match exactly", () => {
+		expect(() => {
+			assertDriversMatchDisks(
+				[Uploads, Backups],
+				[entry(Uploads), entry(Backups)],
+			);
+		}).not.toThrow();
+	});
+
+	it("throws when a declared ref has no matching driver", () => {
+		expect(() => {
+			assertDriversMatchDisks([Uploads, Backups], [entry(Uploads)]);
+		}).toThrow(/missing driver/i);
+	});
+
+	it("throws when the factory returns a driver for an unexpected ref", () => {
+		expect(() => {
+			assertDriversMatchDisks([Uploads], [entry(Uploads), entry(Backups)]);
+		}).toThrow(/unexpected driver/i);
+	});
+
+	it("reports missing and unexpected refs together", () => {
+		expect(() => {
+			assertDriversMatchDisks([Uploads, Backups], [entry(Reports)]);
+		}).toThrow(/missing driver.*unexpected driver/is);
+	});
+});

--- a/packages/flydrive/src/internal/validation.ts
+++ b/packages/flydrive/src/internal/validation.ts
@@ -1,0 +1,76 @@
+import type { DiskRefClass } from "../disk-ref.js";
+import type { FlydriveDiskEntry } from "../flydrive.module-config.js";
+
+function refLabel(ref: DiskRefClass): string {
+	const name = (ref as { name?: string }).name;
+
+	return name && name.length > 0 ? name : "<anonymous disk ref>";
+}
+
+/**
+ * Throws if any ref appears more than once in the declared list.
+ */
+export function assertNoDuplicateRefs(disks: readonly DiskRefClass[]): void {
+	const seen = new Set<DiskRefClass>();
+
+	for (const ref of disks) {
+		if (seen.has(ref)) {
+			throw new Error(
+				`FlydriveModule: duplicate disk reference (${refLabel(ref)}) in \`disks\`.`,
+			);
+		}
+
+		seen.add(ref);
+	}
+}
+
+/**
+ * Throws if `defaultRef` is not present in the declared list.
+ */
+export function assertDefaultInDisks(
+	defaultRef: DiskRefClass,
+	disks: readonly DiskRefClass[],
+): void {
+	if (disks.includes(defaultRef)) {
+		return;
+	}
+
+	throw new Error(
+		`FlydriveModule: \`default\` (${refLabel(defaultRef)}) must be one of the registered \`disks\`.`,
+	);
+}
+
+/**
+ * Throws unless the set of refs declared in `forRootAsync({ disks })`
+ * matches the set of refs returned by the user's `useFactory`. Both a
+ * missing ref and an unexpected ref are errors.
+ */
+export function assertDriversMatchDisks(
+	declared: readonly DiskRefClass[],
+	returned: ReadonlyArray<FlydriveDiskEntry<readonly DiskRefClass[]>>,
+): void {
+	const declaredSet = new Set(declared);
+	const returnedRefs = returned.map((entry) => entry.ref);
+	const returnedSet = new Set(returnedRefs);
+
+	const missing = declared.filter((ref) => !returnedSet.has(ref));
+	const extras = returnedRefs.filter((ref) => !declaredSet.has(ref));
+
+	if (missing.length === 0 && extras.length === 0) {
+		return;
+	}
+
+	const parts: string[] = [];
+
+	if (missing.length > 0) {
+		parts.push(`missing driver for: ${missing.map(refLabel).join(", ")}`);
+	}
+
+	if (extras.length > 0) {
+		parts.push(`unexpected driver for: ${extras.map(refLabel).join(", ")}`);
+	}
+
+	throw new Error(
+		`FlydriveModule.forRootAsync: driver factories do not match the declared \`disks\` (${parts.join("; ")}).`,
+	);
+}

--- a/packages/flydrive/tsconfig.json
+++ b/packages/flydrive/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": ["../../tsconfig.base.json"]
+}

--- a/packages/flydrive/tsdown.config.ts
+++ b/packages/flydrive/tsdown.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsdown";
+import swc from "unplugin-swc";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	unbundle: true,
+	format: ["cjs", "esm"],
+	clean: true,
+	deps: { skipNodeModulesBundle: true },
+	plugins: [swc.rolldown()],
+});

--- a/packages/flydrive/vitest.config.mts
+++ b/packages/flydrive/vitest.config.mts
@@ -1,0 +1,10 @@
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+	test: {
+		name: "@abinnovision/nestjs-flydrive#unit",
+		include: ["src/**/*.spec.ts", "src/**/*.spec.mts"],
+		environment: "node",
+		typecheck: { enabled: true, include: ["src/**/*.spec.ts"] },
+	},
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
 	"packages": {
 		"packages/configx": {},
 		"packages/exceptions": {},
+		"packages/flydrive": {},
 		"packages/hatchet": {
 			"bump-minor-pre-major": false,
 			"bump-patch-for-minor-pre-major": false

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,6 +86,33 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@abinnovision/nestjs-flydrive@workspace:packages/flydrive":
+  version: 0.0.0-use.local
+  resolution: "@abinnovision/nestjs-flydrive@workspace:packages/flydrive"
+  dependencies:
+    "@abinnovision/eslint-config-base": "npm:^3.4.1"
+    "@abinnovision/prettier-config": "npm:^2.2.0"
+    "@nestjs/common": "npm:^11.0.0"
+    "@nestjs/core": "npm:^11.0.0"
+    "@nestjs/testing": "npm:^11.0.0"
+    "@swc/core": "npm:^1.15.18"
+    "@types/node": "npm:^25.8.0"
+    eslint: "npm:^10.3.0"
+    flydrive: "npm:^2.1.0"
+    prettier: "npm:^3.8.3"
+    publint: "npm:^0.3.21"
+    reflect-metadata: "npm:^0.2.2"
+    rxjs: "npm:^7.8.2"
+    tsdown: "npm:^0.22.0"
+    typescript: "npm:^6.0.3"
+    unplugin-swc: "npm:^1.5.9"
+    vitest: "npm:^4.1.6"
+  peerDependencies:
+    "@nestjs/common": ^11.0.0
+    "@nestjs/core": ^11.0.0
+  languageName: unknown
+  linkType: soft
+
 "@abinnovision/nestjs-hatchet@workspace:^, @abinnovision/nestjs-hatchet@workspace:packages/hatchet":
   version: 0.0.0-use.local
   resolution: "@abinnovision/nestjs-hatchet@workspace:packages/hatchet"
@@ -1219,10 +1246,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/retry@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "@humanwhocodes/retry@npm:0.4.2"
-  checksum: 10c0/0235525d38f243bee3bf8b25ed395fbf957fb51c08adae52787e1325673071abe856c7e18e530922ed2dd3ce12ed82ba01b8cee0279ac52a3315fcdc3a69ef0c
+"@humanwhocodes/retry@npm:^0.4.2, @humanwhocodes/retry@npm:^0.4.3":
+  version: 0.4.3
+  resolution: "@humanwhocodes/retry@npm:0.4.3"
+  checksum: 10c0/3775bb30087d4440b3f7406d5a057777d90e4b9f435af488a4923ef249e93615fb78565a85f173a186a076c7706a81d0d57d563a2624e4de2c5c9c66c486ce42
   languageName: node
   linkType: hard
 
@@ -2366,9 +2393,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/testing@npm:^11.1.17":
-  version: 11.1.17
-  resolution: "@nestjs/testing@npm:11.1.17"
+"@nestjs/testing@npm:^11.0.0, @nestjs/testing@npm:^11.1.17":
+  version: 11.1.21
+  resolution: "@nestjs/testing@npm:11.1.21"
   dependencies:
     tslib: "npm:2.8.1"
   peerDependencies:
@@ -2381,7 +2408,7 @@ __metadata:
       optional: true
     "@nestjs/platform-express":
       optional: true
-  checksum: 10c0/fe6408ad155c328beaff4eec2b36bcf853e7bbf2c16806f6cf64dd293fd4de1e3d1232df81bfcece12614de866c7551f728aa8474e2990ae22fe07e69dea8f21
+  checksum: 10c0/8a3cb16d78fdd5162f1f4dc7e2950e6dd0d572921253e972187dd04ef857df77aa88aca0c2ae2677fcc729e4ffad4f3521151805d215b810c33ea2fecff794c9
   languageName: node
   linkType: hard
 
@@ -2504,6 +2531,52 @@ __metadata:
   version: 0.0.12
   resolution: "@package-json/types@npm:0.0.12"
   checksum: 10c0/d9bba086efe7b9901f02f1cff7a68ab23269aeddfb7ee92a16930e219f705bfc188b9fec2dd47265033dbda45ed1514d8a46f46363f38f1ad56bc993754126da
+  languageName: node
+  linkType: hard
+
+"@poppinss/exception@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "@poppinss/exception@npm:1.2.3"
+  checksum: 10c0/44e48400c9f2d33a4904bee99321b89239774bb9210049f1c55864725fd524ff55bc78a5a94a13d5edea93b84e13023c229c88ebba8c2dc717fb4b2205e42ac7
+  languageName: node
+  linkType: hard
+
+"@poppinss/object-builder@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@poppinss/object-builder@npm:1.1.0"
+  checksum: 10c0/1f7d7a86d3db588442479ca7a59e75d0fd49af12986801eb3e52d89c834fe1515bc44f222afbffd8c438df2131ebb3b007cc5cc72aa97b0ed0e1ca85cb7cff61
+  languageName: node
+  linkType: hard
+
+"@poppinss/string@npm:^1.7.1":
+  version: 1.7.2
+  resolution: "@poppinss/string@npm:1.7.2"
+  dependencies:
+    "@types/pluralize": "npm:^0.0.33"
+    case-anything: "npm:^3.1.2"
+    pluralize: "npm:^8.0.0"
+    slugify: "npm:^1.6.9"
+  checksum: 10c0/cb564770558abd15a1874826e719eefd86332c4db3090a673c50d95e8898e9b6b03c90109f4f920f857e5e570c5db0dbaeaf3bc81c930e9803369fbf0dacfd7a
+  languageName: node
+  linkType: hard
+
+"@poppinss/types@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@poppinss/types@npm:1.2.1"
+  checksum: 10c0/63baf881052f4b9ed83f5fe50ed441c9e82b4f3abfd206e42576c1ed38b7dbe61482b7770bf4ebfa93b5e4c5a7e54187f7cd6d21ec3f47eaec9573dbbf535b9d
+  languageName: node
+  linkType: hard
+
+"@poppinss/utils@npm:^7.0.0-next.6":
+  version: 7.0.1
+  resolution: "@poppinss/utils@npm:7.0.1"
+  dependencies:
+    "@poppinss/exception": "npm:^1.2.3"
+    "@poppinss/object-builder": "npm:^1.1.0"
+    "@poppinss/string": "npm:^1.7.1"
+    "@poppinss/types": "npm:^1.2.1"
+    flattie: "npm:^1.1.1"
+  checksum: 10c0/fed3b6f830a3812eff263dbd3c4a8109fb69d336164f1791ebad394cfa3124debfec65f23efa627dbd94855a1bd2321742555ef709435d851c18cae54f7e88c9
   languageName: node
   linkType: hard
 
@@ -4136,6 +4209,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/pluralize@npm:^0.0.33":
+  version: 0.0.33
+  resolution: "@types/pluralize@npm:0.0.33"
+  checksum: 10c0/24899caf85b79dd291a6b6e9b9f3b67b452b18d578d0ac0d531a705bf5ee0361d9386ea1f8532c64de9e22c6e9606c5497787bb5e31bd299c487980436c59785
+  languageName: node
+  linkType: hard
+
 "@types/qs@npm:*, @types/qs@npm:^6.15.0":
   version: 6.15.0
   resolution: "@types/qs@npm:6.15.0"
@@ -5525,6 +5605,13 @@ __metadata:
   version: 1.0.30001792
   resolution: "caniuse-lite@npm:1.0.30001792"
   checksum: 10c0/03bab64b123453e18e7c6747c32bb820be6d82ac78536c5c3704988aaeec411715a2045069fb569f872d73acf1ea64bf83508c9fdfa87b6d012236cde738e1be
+  languageName: node
+  linkType: hard
+
+"case-anything@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "case-anything@npm:3.1.2"
+  checksum: 10c0/9ec1c6a1371795dca8715f66ff83df5dfb9e498dc78b1919a12fc4ac0538156fab4a667690ba7e55a150a385e4e511b3e9bc3bbf5eabb022d716139cc83a9f5b
   languageName: node
   linkType: hard
 
@@ -7189,6 +7276,36 @@ __metadata:
   version: 3.4.2
   resolution: "flatted@npm:3.4.2"
   checksum: 10c0/a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed
+  languageName: node
+  linkType: hard
+
+"flattie@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "flattie@npm:1.1.1"
+  checksum: 10c0/a8f8242c7af126cb2f1aa4a067af338fce609fc4c4df183c626fcc70a46c1878ce4aa88cd0dc8ef8f583ad4e7088a3b11ebeb6a62c9c97d75c0b1b0f08182ee3
+  languageName: node
+  linkType: hard
+
+"flydrive@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "flydrive@npm:2.1.0"
+  dependencies:
+    "@humanwhocodes/retry": "npm:^0.4.3"
+    "@poppinss/utils": "npm:^7.0.0-next.6"
+    etag: "npm:^1.8.1"
+    mime-types: "npm:^3.0.2"
+  peerDependencies:
+    "@aws-sdk/client-s3": ^3.577.0
+    "@aws-sdk/s3-request-presigner": ^3.577.0
+    "@google-cloud/storage": ^7.10.2
+  peerDependenciesMeta:
+    "@aws-sdk/client-s3":
+      optional: true
+    "@aws-sdk/s3-request-presigner":
+      optional: true
+    "@google-cloud/storage":
+      optional: true
+  checksum: 10c0/5549d8e04451e13031547f09f79f844a7cb0fba5ff55ab43f2db61df8f45b9f8e9ad2905425cb91e2838a8b314ca258fa4832f595207079da58888217f5f9c17
   languageName: node
   linkType: hard
 
@@ -10250,7 +10367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pluralize@npm:8.0.0":
+"pluralize@npm:8.0.0, pluralize@npm:^8.0.0":
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
   checksum: 10c0/2044cfc34b2e8c88b73379ea4a36fc577db04f651c2909041b054c981cd863dd5373ebd030123ab058d194ae615d3a97cfdac653991e499d10caf592e8b3dc33
@@ -11262,6 +11379,13 @@ __metadata:
     ansi-styles: "npm:^6.2.3"
     is-fullwidth-code-point: "npm:^5.1.0"
   checksum: 10c0/0ce4aa91febb7cea4a00c2c27bb820fa53b6d2862ce0f80f7120134719f7914fc416b0ed966cf35250a3169e152916392f35917a2d7cad0fcc5d8b841010fa9a
+  languageName: node
+  linkType: hard
+
+"slugify@npm:^1.6.9":
+  version: 1.6.9
+  resolution: "slugify@npm:1.6.9"
+  checksum: 10c0/8473c566ae00c5db26bfbf6182a4a9478ab3c912a9c926e1fdb410736a77228bfca4fdc5c755b46fafa7d2d9900de482fd7a9bd5e5c91128c4743c2c072d88da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds `@abinnovision/nestjs-flydrive`, a NestJS wrapper around [flydrive](https://flydrive.dev). Disks are identified by classes produced by `defineDisk()` and used as DI tokens, type signatures, and identity (no string keys, safe under minification). `forRoot` / `forRootAsync` enforce at the type level that `default` is one of the registered disks. `FlydriveTester` swaps drivers at runtime for integration tests while keeping injected `Disk` references stable via a swappable Proxy that preserves `instanceof Disk`. The package depends only on `flydrive`; AWS / GCS SDKs and `@abinnovision/configx` are not coupled in.