### PR TITLE
docs: add npm version badges and align license sections in package READMEs

### DIFF
--- a/packages/configx/README.md
+++ b/packages/configx/README.md
@@ -1,5 +1,7 @@
 # @abinnovision/nestjs-configx
 
+[![npm](https://img.shields.io/npm/v/@abinnovision/nestjs-configx?style=flat-square)](https://www.npmjs.com/package/@abinnovision/nestjs-configx)
+
 Type-safe configuration for NestJS using [Standard Schema](https://standardschema.dev/).
 
 ## Goals
@@ -88,3 +90,7 @@ export class AppConfigx extends configx(
 ## Error Handling
 
 Invalid configuration throws `InvalidConfigError` at instantiation with details about which fields failed validation.
+
+## License
+
+Apache-2.0

--- a/packages/exceptions/README.md
+++ b/packages/exceptions/README.md
@@ -1,5 +1,7 @@
 # @abinnovision/nestjs-exceptions
 
+[![npm](https://img.shields.io/npm/v/@abinnovision/nestjs-exceptions?style=flat-square)](https://www.npmjs.com/package/@abinnovision/nestjs-exceptions)
+
 NestJS exception handling with entity-focused exceptions and GraphQL support.
 
 ## Installation

--- a/packages/flydrive/README.md
+++ b/packages/flydrive/README.md
@@ -1,5 +1,7 @@
 # @abinnovision/nestjs-flydrive
 
+[![npm](https://img.shields.io/npm/v/@abinnovision/nestjs-flydrive?style=flat-square)](https://www.npmjs.com/package/@abinnovision/nestjs-flydrive)
+
 NestJS integration for [flydrive](https://flydrive.dev). Drivers for the
 local filesystem, AWS S3 (incl. R2, Spaces, Supabase), and Google Cloud
 Storage.

--- a/packages/hatchet/README.md
+++ b/packages/hatchet/README.md
@@ -1,5 +1,7 @@
 # @abinnovision/nestjs-hatchet
 
+[![npm](https://img.shields.io/npm/v/@abinnovision/nestjs-hatchet?style=flat-square)](https://www.npmjs.com/package/@abinnovision/nestjs-hatchet)
+
 NestJS integration for [Hatchet](https://hatchet.run) - a distributed workflow
 orchestration engine. Provides type-safe decorators, services, and event
 handling for building robust workflows.
@@ -231,3 +233,7 @@ export class MyTask extends taskHost(schema) {
   }
 }
 ```
+
+## License
+
+Apache-2.0

--- a/packages/healthz/README.md
+++ b/packages/healthz/README.md
@@ -1,5 +1,7 @@
 # @abinnovision/nestjs-healthz
 
+[![npm](https://img.shields.io/npm/v/@abinnovision/nestjs-healthz?style=flat-square)](https://www.npmjs.com/package/@abinnovision/nestjs-healthz)
+
 Self-mounting health check module for NestJS. Mounts Kubernetes-style
 `/livez`, `/readyz`, and `/healthz` endpoints, and discovers health
 attestors decorated across the application — no central registry,

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -1,5 +1,7 @@
 # @abinnovision/nestjs-toolkit
 
+[![npm](https://img.shields.io/npm/v/@abinnovision/nestjs-toolkit?style=flat-square)](https://www.npmjs.com/package/@abinnovision/nestjs-toolkit)
+
 Common helpers for NestJS apps, with [remeda](https://remedajs.com/) re-exported as `R`.
 
 ## Installation


### PR DESCRIPTION
## Summary

- Adds an npm version badge under the H1 of every `packages/*/README.md` so each package README mirrors the badge style already used in the root README.
- Appends the missing `## License` (Apache-2.0) trailer to `configx` and `hatchet` so all six packages share the same end-of-file structure.

## Test plan

- [ ] Render each `packages/*/README.md` on GitHub and confirm the npm badge displays and links to the correct npm page.
- [ ] Confirm `configx` and `hatchet` now end with `## License\n\nApache-2.0`.