### PR TITLE
docs: add goals, compatibility, examples, and versioning to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 A collection of common packages for NestJS.
 
+## Goals
+
+The packages in this repo share a deliberate house style:
+
+- **Class-based DI** — no string tokens; injection sites are typed and refactor-safe.
+- **Schema-driven types** — Standard Schema (Zod, ArkType, …) and TypeScript module augmentation, not call-site generics.
+- **Testable by default** — every public token is `overrideProvider`-friendly; dedicated fakes where it helps.
+- **Thin wrappers** — we glue best-in-class upstream libraries into Nest, not replace them.
+
 ## Packages
 
 | Package                                                   | Version                                                                                                                                                 | Description                                                                                                                            |
@@ -16,6 +25,24 @@ A collection of common packages for NestJS.
 | [`@abinnovision/nestjs-toolkit`](/packages/toolkit)       | [![npm](https://img.shields.io/npm/v/@abinnovision/nestjs-toolkit?style=flat-square)](https://www.npmjs.com/package/@abinnovision/nestjs-toolkit)       | NestJS utility library providing Remeda functional helpers, string manipulation, and UUID operations for common development tasks.     |
 
 See each package README for installation and usage instructions.
+
+## Compatibility
+
+- **NestJS** 11+
+- **Node.js** 24+
+- **Module formats** — ESM and CJS dual builds; types for both
+- **License** — Apache-2.0
+
+## Examples
+
+Runnable Nest apps under [`examples/`](./examples):
+
+- [`configuration`](./examples/configuration) — `@abinnovision/nestjs-configx` end-to-end.
+- [`hatchet-integration`](./examples/hatchet-integration) — `@abinnovision/nestjs-hatchet` workflows + events.
+
+## Versioning
+
+Each package is versioned independently via [release-please](https://github.com/googleapis/release-please) — versions in the table above are not aligned.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Adds a **Goals** block under the description summarising the shared house style across packages (class-based DI, schema-driven types, testable by default, thin wrappers).
- Adds **Compatibility** (NestJS 11+, Node 24+, ESM+CJS dual, Apache-2.0), **Examples** pointer (`examples/configuration`, `examples/hatchet-integration`), and a one-line **Versioning** note explaining the independent release-please versioning.
- No code or config changes.

## Test plan

- [ ] Render `README.md` on GitHub and confirm headings, table, and relative links resolve.