### PR TITLE
build(flydrive): add prettierignore

### DIFF
--- a/packages/flydrive/.prettierignore
+++ b/packages/flydrive/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
## Summary

Adds the missing `.prettierignore` to `packages/flydrive` so it ignores the auto-generated `CHANGELOG.md` like every other package in the monorepo (`configx`, `exceptions`, `hatchet`, `healthz`, `toolkit`). The flydrive package was introduced in #154 without this file.

## Test plan

- [ ] Confirm file content matches sibling packages (`diff packages/flydrive/.prettierignore packages/configx/.prettierignore` is empty)