### PR TITLE
feat(hatchet): merge emit and emitBulk on Client

### DIFF
--- a/packages/hatchet/README.md
+++ b/packages/hatchet/README.md
@@ -176,11 +176,11 @@ await client.emit(UserCreatedEvent, {
 
 ### Client
 
-| Method                             | Description           |
-| ---------------------------------- | --------------------- |
-| `client.run(ref, input, opts?)`    | Execute task/workflow |
-| `client.emit(event, payload)`      | Emit single event     |
-| `client.emitBulk(event, payloads)` | Emit multiple events  |
+| Method                                    | Description                                    |
+| ----------------------------------------- | ---------------------------------------------- |
+| `client.run(ref, input, opts?)`           | Execute task/workflow                          |
+| `client.emit(event, payload \| payloads)` | Emit one or many events                        |
+| `client.emitBulk(event, payloads)`        | Emit multiple events (deprecated — use `emit`) |
 
 ### Context Types
 
@@ -212,7 +212,7 @@ const result = await runRef.output; // Await when needed
 ### Bulk Event Emission
 
 ```typescript
-await client.emitBulk(OrderEvent, [
+await client.emit(OrderEvent, [
   { orderId: "1", total: 100 },
   { orderId: "2", total: 200 },
 ]);

--- a/packages/hatchet/src/client/client.spec.ts
+++ b/packages/hatchet/src/client/client.spec.ts
@@ -35,7 +35,7 @@ describe("client/client.ts", () => {
 		});
 	});
 
-	describe("emit()", () => {
+	describe("emit() — single input", () => {
 		it("calls SDK events.push with event name", async () => {
 			await client.emit(TestEvent, { id: "123", value: 42 });
 
@@ -82,16 +82,16 @@ describe("client/client.ts", () => {
 		});
 	});
 
-	describe("emitBulk()", () => {
+	describe("emit() — array input", () => {
 		it("returns empty array for empty inputs", async () => {
-			const result = await client.emitBulk(TestEvent, []);
+			const result = await client.emit(TestEvent, []);
 
 			expect(result).toEqual([]);
 			expect(mockHatchetClient.events.bulkPush).not.toHaveBeenCalled();
 		});
 
 		it("calls SDK events.bulkPush with event name", async () => {
-			await client.emitBulk(TestEvent, [
+			await client.emit(TestEvent, [
 				{ id: "1", value: 10 },
 				{ id: "2", value: 20 },
 			]);
@@ -104,7 +104,7 @@ describe("client/client.ts", () => {
 		});
 
 		it("injects event marker into all payloads", async () => {
-			await client.emitBulk(TestEvent, [
+			await client.emit(TestEvent, [
 				{ id: "1", value: 10 },
 				{ id: "2", value: 20 },
 			]);
@@ -122,7 +122,7 @@ describe("client/client.ts", () => {
 		it("passes options to SDK", async () => {
 			const options = { additionalMetadata: { key: "value" } };
 
-			await client.emitBulk(TestEvent, [{ id: "1", value: 10 }], options);
+			await client.emit(TestEvent, [{ id: "1", value: 10 }], options);
 
 			expect(mockHatchetClient.events.bulkPush).toHaveBeenCalledWith(
 				"test:event",
@@ -138,7 +138,7 @@ describe("client/client.ts", () => {
 				scope: "tenant-acme",
 			};
 
-			await client.emitBulk(
+			await client.emit(
 				TestEvent,
 				[
 					{ id: "1", value: 10 },
@@ -173,12 +173,39 @@ describe("client/client.ts", () => {
 				events: mockEvents as any,
 			});
 
-			const result = await client.emitBulk(TestEvent, [
+			const result = await client.emit(TestEvent, [
 				{ id: "1", value: 10 },
 				{ id: "2", value: 20 },
 			]);
 
 			expect(result).toEqual(mockEvents);
+		});
+	});
+
+	describe("emitBulk() — deprecated alias", () => {
+		it("forwards array inputs to SDK events.bulkPush", async () => {
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- intentionally exercises the deprecated alias
+			await client.emitBulk(TestEvent, [
+				{ id: "1", value: 10 },
+				{ id: "2", value: 20 },
+			]);
+
+			expect(mockHatchetClient.events.bulkPush).toHaveBeenCalledWith(
+				"test:event",
+				[
+					{ payload: { id: "1", value: 10, [EVENT_MARKER]: "test:event" } },
+					{ payload: { id: "2", value: 20, [EVENT_MARKER]: "test:event" } },
+				],
+				undefined,
+			);
+		});
+
+		it("returns empty array for empty inputs without calling the SDK", async () => {
+			// eslint-disable-next-line @typescript-eslint/no-deprecated -- intentionally exercises the deprecated alias
+			const result = await client.emitBulk(TestEvent, []);
+
+			expect(result).toEqual([]);
+			expect(mockHatchetClient.events.bulkPush).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/hatchet/src/client/client.ts
+++ b/packages/hatchet/src/client/client.ts
@@ -11,6 +11,22 @@ type EventClient = HatchetClient["events"];
 type EventEmitOptions = Parameters<EventClient["push"]>[2];
 type Event = Awaited<ReturnType<EventClient["push"]>>;
 
+/**
+ * Input accepted by {@link Client.emit} — a single event payload or an array of them.
+ */
+type EventEmitInput<E extends AnyEventDefinition> =
+	| EventInput<E>
+	| EventInput<E>[];
+
+/**
+ * Return type of {@link Client.emit}: an array of events when an array of inputs is
+ * provided, otherwise a single event.
+ */
+type EventEmitReturn<
+	E extends AnyEventDefinition,
+	I extends EventEmitInput<E>,
+> = I extends EventInput<E>[] ? Event[] : Event;
+
 @Injectable()
 export class Client {
 	public readonly run: HostRunFn;
@@ -28,70 +44,87 @@ export class Client {
 	}
 
 	/**
-	 * Emit a single event.
+	 * Emit one or many events of the same type.
+	 *
+	 * Pass a single payload to emit one event, or an array of payloads to emit
+	 * many at once. The return type adjusts accordingly: a single {@link Event}
+	 * for a single input, or an array of {@link Event} for an array of inputs.
 	 *
 	 * @param event The event definition to emit.
-	 * @param input The event payload (must match the event's schema).
+	 * @param input A single event payload, or an array of payloads (each must
+	 *   match the event's schema).
 	 * @param options Optional emit configuration.
-	 * @returns The emitted event.
+	 * @returns The emitted event, or an array of emitted events.
 	 *
 	 * @example
 	 * ```typescript
+	 * // Single event
 	 * await client.emit(UserCreatedEvent, { userId: "123", email: "user@example.com" });
 	 * ```
+	 *
+	 * @example
+	 * ```typescript
+	 * // Multiple events
+	 * await client.emit(OrderPlacedEvent, [
+	 *   { orderId: "1", userId: "123", total: 100 },
+	 *   { orderId: "2", userId: "456", total: 200 },
+	 * ]);
+	 * ```
 	 */
-	public async emit<E extends AnyEventDefinition>(
+	public async emit<E extends AnyEventDefinition, I extends EventEmitInput<E>>(
 		event: E,
-		input: EventInput<E>,
+		input: I,
 		options?: EventEmitOptions,
-	): Promise<Event> {
-		return await this.client.events.push(
+	): Promise<EventEmitReturn<E, I>> {
+		if (Array.isArray(input)) {
+			if (input.length === 0) {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+				return [] as any;
+			}
+
+			const result = await this.client.events.bulkPush(
+				event.name,
+				input.map((single) => ({
+					payload: { ...(single as object), [EVENT_MARKER]: event.name },
+					...(options?.additionalMetadata !== undefined && {
+						additionalMetadata: options.additionalMetadata,
+					}),
+					...(options?.priority !== undefined && {
+						priority: options.priority,
+					}),
+					...(options?.scope !== undefined && { scope: options.scope }),
+				})),
+				options,
+			);
+
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+			return result.events as any;
+		}
+
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return (await this.client.events.push(
 			event.name,
 			{ ...(input as object), [EVENT_MARKER]: event.name },
 			options,
-		);
+		)) as any;
 	}
 
 	/**
 	 * Emit multiple events of the same type.
 	 *
+	 * @deprecated Use {@link Client.emit} with an array of inputs instead. This
+	 *   alias forwards to `emit` and will be removed in a future major version.
+	 *
 	 * @param event The event definition to emit.
 	 * @param inputs Array of event payloads.
 	 * @param options Optional emit configuration.
 	 * @returns Array of emitted events.
-	 *
-	 * @example
-	 * ```typescript
-	 * await client.emitBulk(OrderPlacedEvent, [
-	 *   { orderId: "1", userId: "123", total: 100 },
-	 *   { orderId: "2", userId: "456", total: 200 },
-	 * ]);
-	 * ```
 	 */
 	public async emitBulk<E extends AnyEventDefinition>(
 		event: E,
 		inputs: EventInput<E>[],
 		options?: EventEmitOptions,
 	): Promise<Event[]> {
-		if (inputs.length === 0) {
-			return [];
-		}
-
-		const result = await this.client.events.bulkPush(
-			event.name,
-			inputs.map((input) => ({
-				payload: { ...(input as object), [EVENT_MARKER]: event.name },
-				...(options?.additionalMetadata !== undefined && {
-					additionalMetadata: options.additionalMetadata,
-				}),
-				...(options?.priority !== undefined && {
-					priority: options.priority,
-				}),
-				...(options?.scope !== undefined && { scope: options.scope }),
-			})),
-			options,
-		);
-
-		return result.events;
+		return await this.emit(event, inputs, options);
 	}
 }


### PR DESCRIPTION
Resolves #87 by merging `Client.emitBulk` into `emit`, which now accepts either a single event payload or an array of payloads, with the return type adjusting accordingly (single in → single `Event`, array in → `Event[]`) — mirroring the existing `HostRunFn` pattern. Internally `emit` still dispatches single inputs to `events.push` and arrays to `events.bulkPush`, preserving all current behavior (marker injection, empty-array short-circuit, per-input `priority`/`scope`/`additionalMetadata` propagation). `emitBulk` is retained as a `@deprecated` alias that forwards to `emit`, so no existing callers break. Tests and the README were updated accordingly; `yarn build`, `yarn test-unit`, and lint all pass.