### PR TITLE
fix(hatchet): migrate example off deprecated emitBulk

### DIFF
--- a/examples/hatchet-integration/src/domain/domain.controller.ts
+++ b/examples/hatchet-integration/src/domain/domain.controller.ts
@@ -79,7 +79,7 @@ export class DomainController {
 			}[];
 		},
 	) {
-		const events = await this.client.emitBulk(OrderPlacedEvent, body.orders);
+		const events = await this.client.emit(OrderPlacedEvent, body.orders);
 
 		return {
 			message: `${String(events.length)} order events emitted`,


### PR DESCRIPTION
Migrates the hatchet-integration example off the deprecated `emitBulk` alias to the merged `emit` API introduced in #180. Passing an array of payloads to `emit` preserves the bulk behavior (internally still uses `events.bulkPush`) and returns `Event[]`, so the downstream `events.length` and `events.map(...)` keep working unchanged. The example now models the current, recommended API for consumers.