### PR TITLE
feat(toolkit): add withRetry helper with backoff, jitter and cancellation

### DIFF
--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -14,7 +14,7 @@ yarn add @abinnovision/nestjs-toolkit
 
 The package exposes two surfaces:
 
-- **Direct, data-first helpers** — `slugify(data, opts?)`, `sanitizeString(data, opts?)`, `generateUUID(...)`, `isUUID(...)`, `toUUID(...)`, `isNullishOrEmptyString(...)`, plus UUID namespace constants and types.
+- **Direct, data-first helpers** — `slugify(data, opts?)`, `sanitizeString(data, opts?)`, `generateUUID(...)`, `isUUID(...)`, `toUUID(...)`, `isNullishOrEmptyString(...)`, `withRetry(fn, options)`, plus UUID namespace constants and types.
 - **`R` namespace** — every function from `remeda` plus data-last / pipe-friendly variants of the helpers above: `R.slugify(opts?)`, `R.sanitizeString(opts?)`, `R.isUUID`, `R.isNullishOrEmptyString`.
 
 ```typescript

--- a/packages/toolkit/src/async/index.ts
+++ b/packages/toolkit/src/async/index.ts
@@ -1,0 +1,1 @@
+export * from "./retry.js";

--- a/packages/toolkit/src/async/retry.spec.ts
+++ b/packages/toolkit/src/async/retry.spec.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { withRetry } from "./retry.js";
+
+describe("async/retry.ts", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	describe("#withRetry()", () => {
+		it("resolves with the value on first success", async () => {
+			const fn = vi.fn<() => Promise<string>>().mockResolvedValue("ok");
+
+			await expect(withRetry(fn, { retries: 3 })).resolves.toBe("ok");
+			expect(fn).toHaveBeenCalledTimes(1);
+		});
+
+		it("retries on failure and resolves once it succeeds", async () => {
+			const fn = vi
+				.fn<() => Promise<string>>()
+				.mockRejectedValueOnce(new Error("fail-1"))
+				.mockRejectedValueOnce(new Error("fail-2"))
+				.mockResolvedValue("ok");
+
+			await expect(
+				withRetry(fn, { retries: 5, minDelayMs: 0, jitter: 0 }),
+			).resolves.toBe("ok");
+			expect(fn).toHaveBeenCalledTimes(3);
+		});
+
+		it("throws the last error after exhausting retries", async () => {
+			const fn = vi
+				.fn<() => Promise<never>>()
+				.mockRejectedValueOnce(new Error("fail-1"))
+				.mockRejectedValue(new Error("fail-final"));
+
+			await expect(
+				withRetry(fn, { retries: 2, minDelayMs: 0, jitter: 0 }),
+			).rejects.toThrow("fail-final");
+			// One initial attempt plus two retries.
+			expect(fn).toHaveBeenCalledTimes(3);
+		});
+
+		it("stops immediately when shouldRetry returns false", async () => {
+			const error = new Error("fatal");
+			const fn = vi.fn<() => Promise<never>>().mockRejectedValue(error);
+			const shouldRetry = vi.fn(() => false);
+
+			await expect(
+				withRetry(fn, { retries: 5, minDelayMs: 0, shouldRetry }),
+			).rejects.toBe(error);
+			expect(fn).toHaveBeenCalledTimes(1);
+			expect(shouldRetry).toHaveBeenCalledWith(error);
+		});
+
+		it("invokes onRetry once per retry with a 1-based attempt number", async () => {
+			const fn = vi
+				.fn<() => Promise<string>>()
+				.mockRejectedValueOnce(new Error("fail-1"))
+				.mockRejectedValueOnce(new Error("fail-2"))
+				.mockResolvedValue("ok");
+			const onRetry = vi.fn();
+
+			await withRetry(fn, { retries: 5, minDelayMs: 0, jitter: 0, onRetry });
+
+			expect(onRetry).toHaveBeenCalledTimes(2);
+			expect(onRetry).toHaveBeenNthCalledWith(1, expect.any(Error), 1);
+			expect(onRetry).toHaveBeenNthCalledWith(2, expect.any(Error), 2);
+		});
+
+		it("applies exponential backoff capped at maxDelayMs", async () => {
+			vi.useFakeTimers();
+			const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+			const fn = vi
+				.fn<() => Promise<never>>()
+				.mockRejectedValue(new Error("x"));
+
+			const promise = withRetry(fn, {
+				retries: 4,
+				minDelayMs: 100,
+				maxDelayMs: 500,
+				factor: 2,
+				jitter: 0,
+			}).catch(() => "settled");
+
+			await vi.runAllTimersAsync();
+			await promise;
+
+			const delays = setTimeoutSpy.mock.calls.map((call) => call[1]);
+			// 100, 200, 400, then 800 capped to 500.
+			expect(delays).toEqual([100, 200, 400, 500]);
+		});
+
+		it("does not invoke fn when the signal is already aborted", async () => {
+			const controller = new AbortController();
+			controller.abort();
+			const fn = vi.fn<() => Promise<string>>().mockResolvedValue("ok");
+
+			await expect(
+				withRetry(fn, { retries: 3, signal: controller.signal }),
+			).rejects.toBe(controller.signal.reason);
+			expect(fn).not.toHaveBeenCalled();
+		});
+
+		it("aborts a pending backoff and rejects with the signal reason", async () => {
+			vi.useFakeTimers();
+			const controller = new AbortController();
+			const fn = vi
+				.fn<() => Promise<never>>()
+				.mockRejectedValue(new Error("x"));
+
+			// Swallow the rejection so driving the fake timers does not surface it
+			// as an unhandled rejection before we assert on it.
+			const guarded = withRetry(fn, {
+				retries: 5,
+				minDelayMs: 10_000,
+				jitter: 0,
+				signal: controller.signal,
+			}).catch((error: unknown) => error);
+
+			// Let the first attempt fail and schedule the backoff.
+			await vi.advanceTimersByTimeAsync(0);
+			expect(fn).toHaveBeenCalledTimes(1);
+
+			controller.abort();
+
+			await expect(guarded).resolves.toBe(controller.signal.reason);
+			expect(fn).toHaveBeenCalledTimes(1);
+		});
+
+		it("calls fn once and does not retry when retries is 0", async () => {
+			const error = new Error("once");
+			const fn = vi.fn<() => Promise<never>>().mockRejectedValue(error);
+			const onRetry = vi.fn();
+
+			await expect(withRetry(fn, { retries: 0, onRetry })).rejects.toBe(error);
+			expect(fn).toHaveBeenCalledTimes(1);
+			expect(onRetry).not.toHaveBeenCalled();
+		});
+
+		it("invokes onRetry once per retry but never for the final failure", async () => {
+			const fn = vi
+				.fn<() => Promise<never>>()
+				.mockRejectedValue(new Error("x"));
+			const onRetry = vi.fn();
+
+			await expect(
+				withRetry(fn, { retries: 2, minDelayMs: 0, jitter: 0, onRetry }),
+			).rejects.toThrow("x");
+			// Three attempts, two retries: onRetry fires twice, not for the throw.
+			expect(onRetry).toHaveBeenCalledTimes(2);
+		});
+
+		it("rejects a negative retries count with a TypeError", async () => {
+			const fn = vi.fn<() => Promise<string>>().mockResolvedValue("ok");
+
+			await expect(withRetry(fn, { retries: -1 })).rejects.toThrow(TypeError);
+			expect(fn).not.toHaveBeenCalled();
+		});
+
+		it("applies symmetric jitter within the configured fraction", async () => {
+			vi.useFakeTimers();
+			const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+			// rand=1 -> +jitter (upper bound), rand=0 -> -jitter (lower bound).
+			vi.spyOn(Math, "random").mockReturnValueOnce(1).mockReturnValueOnce(0);
+			const fn = vi
+				.fn<() => Promise<never>>()
+				.mockRejectedValue(new Error("x"));
+
+			const promise = withRetry(fn, {
+				retries: 2,
+				minDelayMs: 1000,
+				maxDelayMs: 100_000,
+				factor: 1,
+				jitter: 0.25,
+			}).catch(() => "settled");
+
+			await vi.runAllTimersAsync();
+			await promise;
+
+			const delays = setTimeoutSpy.mock.calls.map((call) => call[1]);
+			// base stays 1000 (factor 1); +25% -> 1250, -25% -> 750.
+			expect(delays).toEqual([1250, 750]);
+		});
+
+		it("never schedules a delay beyond maxDelayMs even with jitter", async () => {
+			vi.useFakeTimers();
+			const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+			// Force maximum positive jitter on every attempt.
+			vi.spyOn(Math, "random").mockReturnValue(1);
+			const fn = vi
+				.fn<() => Promise<never>>()
+				.mockRejectedValue(new Error("x"));
+
+			const promise = withRetry(fn, {
+				retries: 3,
+				minDelayMs: 1000,
+				maxDelayMs: 2000,
+				factor: 10,
+				jitter: 0.5,
+			}).catch(() => "settled");
+
+			await vi.runAllTimersAsync();
+			await promise;
+
+			const delays = setTimeoutSpy.mock.calls.map((call) => call[1] ?? 0);
+			// Without the post-jitter clamp the base-capped 2000 would reach 3000.
+			expect(Math.max(...delays)).toBe(2000);
+		});
+
+		it("does not invoke onRetry when the signal aborts during fn", async () => {
+			const controller = new AbortController();
+			const onRetry = vi.fn();
+			const fn = vi.fn<() => Promise<never>>().mockImplementation(() => {
+				controller.abort();
+				return Promise.reject(new Error("fn-failed"));
+			});
+
+			const guarded = withRetry(fn, {
+				retries: 3,
+				minDelayMs: 0,
+				jitter: 0,
+				onRetry,
+				signal: controller.signal,
+			}).catch((error: unknown) => error);
+
+			const result = await guarded;
+
+			expect(result).toBe(controller.signal.reason);
+			expect(onRetry).not.toHaveBeenCalled();
+			expect(fn).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/packages/toolkit/src/async/retry.ts
+++ b/packages/toolkit/src/async/retry.ts
@@ -1,0 +1,168 @@
+/**
+ * Pause for the given number of milliseconds. If the optional AbortSignal fires
+ * first, the pending timer is cleared and the promise rejects with the signal's
+ * reason.
+ */
+const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
+	new Promise<void>((resolve, reject) => {
+		signal?.throwIfAborted();
+
+		// Auto-removes the abort listener once the timer resolves normally, so a
+		// long-lived signal does not accumulate listeners across many sleeps.
+		const cleanup = new AbortController();
+
+		const timer = setTimeout(() => {
+			cleanup.abort();
+			resolve();
+		}, ms);
+
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timer);
+				// eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- propagate the AbortSignal's reason verbatim
+				reject(signal.reason);
+			},
+			{ signal: cleanup.signal },
+		);
+	});
+
+/**
+ * Configuration for {@link withRetry}.
+ */
+export interface RetryOptions {
+	/**
+	 * Number of retry attempts after the initial attempt. The operation is
+	 * therefore invoked at most `retries + 1` times.
+	 */
+	retries: number;
+
+	/**
+	 * Base delay between attempts in milliseconds; grows exponentially with
+	 * each attempt (see `factor`).
+	 *
+	 * @default 250
+	 */
+	minDelayMs?: number;
+
+	/**
+	 * Hard upper bound for a single backoff delay in milliseconds, enforced
+	 * after jitter. Prevents exponential growth from producing unbounded waits.
+	 *
+	 * @default 30000
+	 */
+	maxDelayMs?: number;
+
+	/**
+	 * Multiplier applied to the delay on each successive attempt. A value of
+	 * `2` doubles the delay every time.
+	 *
+	 * @default 2
+	 */
+	factor?: number;
+
+	/**
+	 * Fraction of random jitter applied to each delay to avoid thundering-herd
+	 * retries. `0` disables jitter; `0.25` spreads each delay by +/-25%.
+	 *
+	 * @default 0.25
+	 */
+	jitter?: number;
+
+	/**
+	 * Decide whether a given error is retryable. Defaults to always retry.
+	 */
+	shouldRetry?: (error: unknown) => boolean;
+
+	/**
+	 * Invoked before each retry with the error and the upcoming attempt number
+	 * (1-based).
+	 */
+	onRetry?: (error: unknown, attempt: number) => void;
+
+	/**
+	 * Optional signal to abort the retry loop. When aborted, any pending
+	 * backoff stops immediately and the call rejects with the signal's reason.
+	 */
+	signal?: AbortSignal;
+}
+
+/**
+ * Retry an async operation with exponential backoff and jitter.
+ *
+ * A small local helper is used instead of `p-retry` because that package is
+ * ESM-only, while this library is published as both ESM and CommonJS; a
+ * `require()` of an ESM-only dependency would fail the package's CJS
+ * resolution gate.
+ *
+ * The `signal` aborts the retry loop itself — a pending backoff is interrupted
+ * and no further attempts are made — but it is NOT forwarded to `fn`. To cancel
+ * an in-flight `fn()` call as well, `fn` must observe the same signal (e.g. pass
+ * it to `fetch`).
+ *
+ * @example
+ * ```typescript
+ * const data = await withRetry(() => fetchFlaky(), {
+ *   retries: 3,
+ *   shouldRetry: (error) => !(error instanceof FatalError),
+ *   signal: AbortSignal.timeout(5_000),
+ * });
+ * ```
+ *
+ * @param fn - The operation to run.
+ * @param options - Retry behaviour configuration.
+ * @returns The resolved value of the operation.
+ * @throws TypeError if `retries` is not a non-negative integer.
+ * @throws The last error if all attempts fail, or the signal's reason if aborted.
+ */
+export async function withRetry<T>(
+	fn: () => Promise<T>,
+	options: RetryOptions,
+): Promise<T> {
+	const {
+		retries,
+		minDelayMs = 250,
+		maxDelayMs = 30_000,
+		factor = 2,
+		jitter = 0.25,
+		shouldRetry = (): boolean => true,
+		onRetry,
+		signal,
+	} = options;
+
+	if (!Number.isInteger(retries) || retries < 0) {
+		throw new TypeError("withRetry: `retries` must be a non-negative integer.");
+	}
+
+	let lastError: unknown;
+
+	for (let attempt = 0; attempt <= retries; attempt++) {
+		signal?.throwIfAborted();
+
+		try {
+			// eslint-disable-next-line no-await-in-loop -- sequential retry is intentional
+			return await fn();
+		} catch (error) {
+			lastError = error;
+
+			// If the signal aborted while fn was running, reject with the abort
+			// reason now instead of firing onRetry for a retry that cannot happen.
+			signal?.throwIfAborted();
+
+			if (attempt === retries || !shouldRetry(error)) {
+				break;
+			}
+
+			onRetry?.(error, attempt + 1);
+
+			const base = Math.min(minDelayMs * factor ** attempt, maxDelayMs);
+			const jittered = base + base * jitter * (Math.random() * 2 - 1);
+			const delayMs = Math.min(maxDelayMs, Math.max(0, Math.round(jittered)));
+
+			// eslint-disable-next-line no-await-in-loop -- backoff delay between attempts
+			await sleep(delayMs, signal);
+		}
+	}
+
+	throw lastError;
+}

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -5,6 +5,7 @@
  */
 
 export { R } from "./remeda.js";
+export * from "./async/index.js";
 export * from "./assert/index.js";
 export * from "./equality/index.js";
 export * from "./string/index.js";


### PR DESCRIPTION
Adds `withRetry`, a zero-dependency async retry helper in `@abinnovision/nestjs-toolkit` (`src/async/retry.ts`) supporting retries, exponential backoff with a configurable `factor`, a hard `maxDelayMs` ceiling, symmetric jitter, `shouldRetry`, `onRetry`, and `AbortSignal` cancellation. It is hand-rolled instead of using `p-retry` because the package publishes dual CJS+ESM behind an `attw` (node16) + `publint` gate, where an ESM-only dependency would fail CJS resolution; the new `src/async` barrel is wired into the root export and the README lists the helper. Colocated vitest specs cover success, retry/exhaustion, `shouldRetry`/`onRetry`, jitter bounds and the `maxDelayMs` cap, negative-`retries` validation, and abort before/during `fn` and during backoff, at 100% coverage. The build passes with `attw` reporting no problems, confirming the dual CJS/ESM output remains valid.