### PR TITLE
docs(toolkit): describe README helper surfaces by category

### DIFF
--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -14,8 +14,8 @@ yarn add @abinnovision/nestjs-toolkit
 
 The package exposes two surfaces:
 
-- **Direct, data-first helpers** — `slugify(data, opts?)`, `sanitizeString(data, opts?)`, `generateUUID(...)`, `isUUID(...)`, `toUUID(...)`, `isNullishOrEmptyString(...)`, `withRetry(fn, options)`, plus UUID namespace constants and types.
-- **`R` namespace** — every function from `remeda` plus data-last / pipe-friendly variants of the helpers above: `R.slugify(opts?)`, `R.sanitizeString(opts?)`, `R.isUUID`, `R.isNullishOrEmptyString`.
+- **Direct helpers** — string, UUID, async, equality, and assertion helpers, imported and called directly.
+- **`R` namespace** — every function from `remeda`, plus pipe-friendly variants of selected helpers for use in `R.pipe(...)`.
 
 ```typescript
 import { R, slugify, generateUUID, isUUID } from "@abinnovision/nestjs-toolkit";
@@ -29,7 +29,7 @@ const id = generateUUID();
 isUUID(id); // true
 ```
 
-See the [remeda documentation](https://remedajs.com/docs/) for the full `R.*` surface, and the inline TSDoc for option shapes and UUID version overloads.
+See the [remeda documentation](https://remedajs.com/docs/) for the full `R.*` surface, and the inline TSDoc for the complete helper catalog, option shapes, and UUID version overloads.
 
 ## License
 


### PR DESCRIPTION
Trims the toolkit README's hand-maintained symbol list down to category-level descriptions (string, UUID, async, equality, assertion) that map 1:1 to the `src/` modules, so the inventory no longer drifts and now reflects the previously-omitted `deepEqual` and `assertNever` helpers. Removes the inaccurate "data-first" label and the "data-last variants" claim about the re-exported `R` guards, and points the TSDoc note at the complete helper catalog. Docs-only — no code or behavior changes; the code examples were verified against source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)